### PR TITLE
Rename genes seurat for adt to fix #61

### DIFF
--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -4491,7 +4491,7 @@ RenameGenesSeurat <- function(obj = ls.Seurat[[i]], newnames = HGNC.updated[[i]]
 
   if (nrow(assayobj) == length(newnames)) {
     if (length(assayobj@counts)) assayobj@counts@Dimnames[[1]]             <- newnames
-    if (length(assayobj@data))   attr(assayobj@data, "dimnames")[[1]]      <- newnames
+    if (length(assayobj@data))   assayobj@data@Dimnames[[1]]               <- newnames
     if (length(assayobj@scale.data) > 0) assayobj@scale.data@Dimnames[[1]] <- newnames
     # if (length(obj@meta.data)) rownames(obj@meta.data)          <- newnames
   } else {


### PR DESCRIPTION
Attempt to fix #61.
I've written a new function `check_and_rename` which takes a slot, performes various tests and performes renaming.
This way it can be used on all types of slots in a consistent manner. 