### PR TITLE
fix: correct documentation typos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,11 +4,11 @@ Version: 2.8.5
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Author: Abel Vertesy <av@imba.oeaw.ac.at> [aut, cre]
-Description: Seurat.utils Is a collection of utility functions for Seurat
-    single cell analysis.  Functions allow 3D plotting, visualisation of
+Description: Seurat.utils is a collection of utility functions for Seurat
+    single cell analysis. Functions allow 3D plotting, visualisation of
     statistics & QC, the automation / multiplexing of plotting,
-    interaction with the Seurat object, etc.  Some functionalities require
-    functions from CodeAndRoll and MarkdownReports libraries.
+    interaction with the Seurat object, etc. Some functionalities require
+    functions from CodeAndRoll2 and MarkdownReports libraries.
 License: GPL-3 + file LICENSE
 BugReports: https://github.com/vertesy/Seurat.utils/issues
 Depends: 

--- a/Development/Create_the_Seurat.utils_Package.OLD.R
+++ b/Development/Create_the_Seurat.utils_Package.OLD.R
@@ -25,9 +25,9 @@ DESCRIPTION <- list(
   "Title" = "Seurat.utils - utility functions for Seurat",
   "Author" = person(given = "Abel", family = "Vertesy", email = "av@imba.oeaw.ac.at", role = c("aut", "cre")),
   "Authors@R" = 'person(given = "Abel", family = "Vertesy", email = "av@imba.oeaw.ac.at", role =  c("aut", "cre") )',
-  "Description" = "Seurat.utils Is a collection of utility functions for Seurat v3.
-    Functions allow the automation / multiplexing of plotting, 3D plotting, visualisation of statistics &
-    QC, interaction with the Seurat object, etc. Some functionalities require functions from CodeAndRoll and MarkdownReports libraries.",
+    "Description" = "Seurat.utils is a collection of utility functions for Seurat v3.
+      Functions allow the automation / multiplexing of plotting, 3D plotting, visualisation of statistics &
+      QC, interaction with the Seurat object, etc. Some functionalities require functions from CodeAndRoll2 and MarkdownReports libraries.",
   "License" = "GPL-3 + file LICENSE",
   "Version" = package.version,
   "Packaged" = Sys.time()

--- a/Development/config.R
+++ b/Development/config.R
@@ -5,10 +5,10 @@ DESCRIPTION <- list(
   package.name = "Seurat.utils",
   version = "2.8.6",
   title = "Seurat.utils - utility functions for Seurat",
-  description = "Seurat.utils Is a collection of utility functions for Seurat single cell analysis.
-    Functions allow 3D plotting, visualisation of statistics & QC,
-    the automation / multiplexing of plotting, interaction with the Seurat object, etc.
-    Some functionalities require functions from CodeAndRoll and MarkdownReports libraries.",
+    description = "Seurat.utils is a collection of utility functions for Seurat single cell analysis.
+      Functions allow 3D plotting, visualisation of statistics & QC,
+      the automation / multiplexing of plotting, interaction with the Seurat object, etc.
+      Some functionalities require functions from CodeAndRoll2 and MarkdownReports libraries.",
   depends = "tidyverse, Seurat, Stringendo, CodeAndRoll2, ggExpress, magrittr",
   imports = "cowplot, dplyr, ggcorrplot, ggpubr, ggrepel, HGNChelper, htmlwidgets,
     Matrix, matrixStats, princurve, pheatmap,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seurat.utils ![status: active](https://raw.githubusercontent.com/vertesy/TheCorvinas/master/GitHub/Badges/active.svg) [![DOI](https://zenodo.org/badge/248721133.svg)](https://zenodo.org/badge/latestdoi/248721133) 
 
-`Seurat.utils` Is a collection of utility functions for Seurat. Functions allow the automation / multiplexing of plotting, 3D plotting, visualisation of statistics & QC, interaction with the Seurat object, etc.  Some functionalities require functions from [CodeAndRoll2](https://github.com/vertesy/CodeAndRoll2), [ReadWriter](https://github.com/vertesy/ReadWriter), [Stringendo](https://github.com/vertesy/Stringendo), [ggExpressDev](https://github.com/vertesy/ggExpressDev), [MarkdownReports](https://github.com/vertesy/MarkdownReports), and the [Rocinante](https://github.com/vertesy/Rocinante) (See installation).
+`Seurat.utils` is a collection of utility functions for Seurat. Functions allow the automation / multiplexing of plotting, 3D plotting, visualisation of statistics & QC, interaction with the Seurat object, etc. Some functionalities require functions from [CodeAndRoll2](https://github.com/vertesy/CodeAndRoll2), [ReadWriter](https://github.com/vertesy/ReadWriter), [Stringendo](https://github.com/vertesy/Stringendo), [ggExpressDev](https://github.com/vertesy/ggExpressDev), [MarkdownReports](https://github.com/vertesy/MarkdownReports), and the [Rocinante](https://github.com/vertesy/Rocinante) (see installation).
 
 [TOC]
 
@@ -14,7 +14,7 @@ Seurat.utils relies on:
 - [ReadWriter](https://github.com/vertesy/ReadWriter)
 - [CodeAndRoll2](https://github.com/vertesy/CodeAndRoll2)
 - [MarkdownHelpers](https://github.com/vertesy/MarkdownHelpers)
-- [Markdownreports](https://github.com/vertesy/Markdownreports)
+- [MarkdownReports](https://github.com/vertesy/MarkdownReports)
 - [ggExpress](https://github.com/vertesy/ggExpress)
 
 ... and provides functions for
@@ -35,7 +35,7 @@ devtools::install_github(repo = "vertesy/Stringendo", upgrade = F)
 devtools::install_github(repo = "vertesy/CodeAndRoll2", upgrade = F)
 devtools::install_github(repo = "vertesy/ReadWriter", upgrade = F)
 devtools::install_github(repo = "vertesy/MarkdownHelpers", upgrade = F)
-devtools::install_github(repo = "vertesy/Markdownreports", upgrade = F)
+devtools::install_github(repo = "vertesy/MarkdownReports", upgrade = F)
 devtools::install_github(repo = "vertesy/ggExpress", upgrade = F)
 
 # Recommended
@@ -56,7 +56,7 @@ devtools::install_github(repo = "vertesy/Seurat.utils", upgrade = F)
 require("Seurat.utils")
 ```
 
-**NOTE: If you type 'all' when R asks to update dependencies, you may get into installation errors / infinite loops. If updating fails, type 'no' when prompted. **
+**NOTE**: If you type 'all' when R asks to update dependencies, you may get into installation errors / infinite loops. If updating fails, type 'no' when prompted.
 
 Alternatively, you simply source it from the web. 
 *This way function help will not work, and you will have no local copy of the code on your hard drive.*

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Metadata.Rmd
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Metadata.Rmd
@@ -1,10 +1,11 @@
 # Vignette for 29 functions in Seurat.Utils.Metadata.R
 Updated: 2024/03/26 11:27
 
-Seurat.utils Is a collection of utility functions for Seurat single cell analysis.
+Seurat.utils is a collection of utility functions for Seurat single cell analysis.
     Functions allow 3D plotting, visualisation of statistics & QC,
     the automation / multiplexing of plotting, interaction with the Seurat object, etc.
-    Some functionalities require functions from CodeAndRoll and MarkdownReports libraries.> For details, please use the `help()` function, or browse the source code.
+    Some functionalities require functions from CodeAndRoll2 and MarkdownReports libraries.
+> For details, please use the `help()` function, or browse the source code.
 
 #### 1. Get Metadata Column Names Matching Pattern: `getMetaColnames()`
 Retrieves column names from an object's metadata that match a specified pattern.

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Metadata.html
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Metadata.html
@@ -355,11 +355,11 @@ display: none;
 <div id="vignette-for-29-functions-in-seurat.utils.metadata.r" class="section level1">
 <h1>Vignette for 29 functions in Seurat.Utils.Metadata.R</h1>
 <p>Updated: 2024/03/26 11:27</p>
-<p>Seurat.utils Is a collection of utility functions for Seurat single
+<p>Seurat.utils is a collection of utility functions for Seurat single
 cell analysis. Functions allow 3D plotting, visualisation of statistics
 &amp; QC, the automation / multiplexing of plotting, interaction with
 the Seurat object, etc. Some functionalities require functions from
-CodeAndRoll and MarkdownReports libraries.&gt; For details, please use
+CodeAndRoll2 and MarkdownReports libraries. For details, please use
 the <code>help()</code> function, or browse the source code.</p>
 <div id="get-metadata-column-names-matching-pattern-getmetacolnames" class="section level4">
 <h4>1. Get Metadata Column Names Matching Pattern:

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Rmd
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Rmd
@@ -1,10 +1,11 @@
 # Vignette for 100 functions in Seurat.Utils.R
 Updated: 2024/03/26 11:33
 
-Seurat.utils Is a collection of utility functions for Seurat single cell analysis.
+Seurat.utils is a collection of utility functions for Seurat single cell analysis.
     Functions allow 3D plotting, visualisation of statistics & QC,
     the automation / multiplexing of plotting, interaction with the Seurat object, etc.
-    Some functionalities require functions from CodeAndRoll and MarkdownReports libraries.> For details, please use the `help()` function, or browse the source code.
+    Some functionalities require functions from CodeAndRoll2 and MarkdownReports libraries.
+> For details, please use the `help()` function, or browse the source code.
 
 #### 1. parallel.computing.by.future: `parallel.computing.by.future()`
 Run gc(), load multi-session computing and extend memory limits.

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Visualization.No.Plots.html
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Visualization.No.Plots.html
@@ -355,11 +355,11 @@ display: none;
 <div id="vignette-for-57-functions-in-seurat.utils.visualization.r" class="section level1">
 <h1>Vignette for 57 functions in Seurat.Utils.Visualization.R</h1>
 <p>Updated: 2024/03/25 15:51</p>
-<p>Seurat.utils Is a collection of utility functions for Seurat single
+<p>Seurat.utils is a collection of utility functions for Seurat single
 cell analysis. Functions allow 3D plotting, visualisation of statistics
 &amp; QC, the automation / multiplexing of plotting, interaction with
 the Seurat object, etc. Some functionalities require functions from
-CodeAndRoll and MarkdownReports libraries.&gt; For details, please use
+CodeAndRoll2 and MarkdownReports libraries. For details, please use
 the <code>help()</code> function, or browse the source code.</p>
 <div id="plotfilters-plotfilters" class="section level4">
 <h4>1. PlotFilters: <code>PlotFilters()</code></h4>

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Visualization.Rmd
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.Visualization.Rmd
@@ -1,10 +1,11 @@
 # Vignette for 57 functions in Seurat.Utils.Visualization.R
 Updated: 2024/03/25 15:51
 
-Seurat.utils Is a collection of utility functions for Seurat single cell analysis.
+Seurat.utils is a collection of utility functions for Seurat single cell analysis.
     Functions allow 3D plotting, visualisation of statistics & QC,
     the automation / multiplexing of plotting, interaction with the Seurat object, etc.
-    Some functionalities require functions from CodeAndRoll and MarkdownReports libraries.> For details, please use the `help()` function, or browse the source code.
+    Some functionalities require functions from CodeAndRoll2 and MarkdownReports libraries.
+> For details, please use the `help()` function, or browse the source code.
 
 #### 1. PlotFilters: `PlotFilters()`
 Plot filtering threshold and distributions, using four panels to highlight the relation between Gene- and UMI-count, ribosomal- and mitochondrial-content.

--- a/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.html
+++ b/Vignettes/Auto.Generated.No.Plots/Vignette.Seurat.Utils.html
@@ -355,11 +355,11 @@ display: none;
 <div id="vignette-for-100-functions-in-seurat.utils.r" class="section level1">
 <h1>Vignette for 100 functions in Seurat.Utils.R</h1>
 <p>Updated: 2024/03/26 11:33</p>
-<p>Seurat.utils Is a collection of utility functions for Seurat single
+<p>Seurat.utils is a collection of utility functions for Seurat single
 cell analysis. Functions allow 3D plotting, visualisation of statistics
 &amp; QC, the automation / multiplexing of plotting, interaction with
 the Seurat object, etc. Some functionalities require functions from
-CodeAndRoll and MarkdownReports libraries.&gt; For details, please use
+CodeAndRoll2 and MarkdownReports libraries. For details, please use
 the <code>help()</code> function, or browse the source code.</p>
 <div id="parallel.computing.by.future-parallel.computing.by.future" class="section level4">
 <h4>1. parallel.computing.by.future:


### PR DESCRIPTION
## Summary
- fix capitalization and repository name typos in README
- clarify package description and dependency names
- update vignettes and development scripts with consistent wording

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894a0d2faa8832cb5298b78581ec724