### PR TITLE
Fix spelling in function documentation

### DIFF
--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -120,7 +120,7 @@ metaColnameExists <- function(col_name, obj = combined.obj) {
 #' @description Retrieves a specified metadata column from a Seurat object and returns it as a named vector.
 #' @param col A string specifying the name of the metadata column to be retrieved. Default: 'batch'.
 #' @param obj A Seurat object from which the metadata column will be retrieved. Default: combined.obj.
-#' @param as_numeric A logical flag indicating whether the returned values should be converted to numeric format. Default: `FALSE`. (FALSE).
+#' @param as_numeric A logical flag indicating whether the returned values should be converted to numeric format. Default: `FALSE`.
 #' @return A named vector containing the values from the specified metadata column. If 'as_numeric' is TRUE, the values are converted to numeric format.
 #' @examples
 #' \dontrun{
@@ -188,7 +188,7 @@ get_levels_seu <- function(obj, ident, max_levels = 100, dput = TRUE) {
 #'   Defaults to list('median' = median, 'mean' = mean).
 #' @param verbose Logical flag indicating whether to print detailed information about the metrics
 #'   calculation process. Defaults to TRUE.
-#' @param max.categ max number of groups in ident.
+#' @param max.categ Maximum number of groups in ident.
 #'
 #' @return A list containing data frames with calculated metrics for each specified metadata feature,
 #'   grouped by the identity categories. Each data frame corresponds to one of the specified metrics.
@@ -337,7 +337,7 @@ getMedianMetric.lsObj <- function(ls.obj = ls.Seurat, n.datasets = length(ls.Seu
 #' @param ident A string specifying the name of the metadata column from which to retrieve cell IDs. Default: 'res.0.6'.
 #' @param ident_values A vector of values to match in the metadata column. Default: `NA`.
 #' @param obj The Seurat object from which to retrieve the cell IDs. Default: combined.obj.
-#' @param inverse A boolean value indicating whether to inverse the match, i.e., retrieve cell IDs that do not match the provided list of ident_values. Default: `FALSE`.
+#' @param inverse A boolean value indicating whether to invert the match, i.e., retrieve cell IDs that do not match the provided list of ident_values. Default: `FALSE`.
 #' @return A vector of cell IDs that match (or don't match, if `inverse = TRUE`) the provided list of values.
 #' @examples
 #' \dontrun{

--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -409,7 +409,7 @@ PercentInTranscriptome <- function(
 # _________________________________________________________________________________________________
 #' @title Histogram All Genes' Expression Level and a Highlighted Gene
 #'
-#' @description Shows a comparison of the expression level of the chose gene to all genes.
+#' @description Shows a comparison of the expression level of the chosen gene to all genes.
 #' Very useful to see if the gene has a meaningful expression level. This function generates a
 #' histogram to visualize the expression level distribution of a specified gene across all cells in
 #' a Seurat object. It highlights the position of the gene of interest within the overall distribution.

--- a/R/Seurat.utils.less.used.R
+++ b/R/Seurat.utils.less.used.R
@@ -22,7 +22,7 @@
 #' @param writeCBCtable A logical value indicating whether to write out a list of cell barcodes (CBC) as a tsv file. Default: `TRUE`.
 #' @param depth An integer value specifying the depth of scan (i.e., how many levels below the InputDir). Default: 2.
 #' @param sample.barcoding A logical value indicating whether Cell Ranger was run with sample barcoding. Default: `FALSE`.
-#' @param sort_alphanumeric sort files alphanumeric? Default: `TRUE`.
+#' @param sort_alphanumeric Sort files alphanumerically? Default: `TRUE`.
 #' @examples
 #' \dontrun{
 #' if (interactive()) Convert10Xfolders(InputDir)
@@ -136,7 +136,7 @@ Convert10Xfolders_v1 <- function(
 #' @param pt_size Size of points. Default: 0.5
 #' @param name.suffix Suffix to append to the plot's name. Default: NULL
 #' @param width Width of the plot. Default: hA4
-#' @param heigth Height of the plot. Default: 1.75 * wA4
+#' @param height Height of the plot. Default: 1.75 * wA4
 #' @param filetype Filetype to save plot as. Default: 'pdf'
 #' @param ... Pass any other parameter to the internally called functions (most of them should work).
 #' @seealso
@@ -154,7 +154,7 @@ plot.UMAP.tSNE.sidebyside <- function(obj = combined.obj, grouping = "res.0.6", 
                                       no_axes = TRUE,
                                       pt_size = 0.5,
                                       name.suffix = NULL,
-                                      width = hA4, heigth = 1.75 * wA4, filetype = "pdf", ...) {
+                                      width = hA4, height = 1.75 * wA4, filetype = "pdf", ...) {
   p1 <- Seurat::DimPlot(
     object = obj, reduction.use = "tsne", no.axes = no_axes, cells.use = cells_use,
     no.legend = no_legend, do.return = do_return, do.label = do_label, label.size = label_size,
@@ -177,7 +177,7 @@ plot.UMAP.tSNE.sidebyside <- function(obj = combined.obj, grouping = "res.0.6", 
     ncol = 2 # we're saving a grid plot of 2 columns
     , nrow = 1 # and 2 rows
     , base_width = width,
-    base_height = heigth
+    base_height = height
     # each individual subplot should have an aspect ratio of 1.3
     # , base_aspect_ratio = 1.5
   )

--- a/man/Convert10Xfolders.Rd
+++ b/man/Convert10Xfolders.Rd
@@ -47,7 +47,7 @@ Convert10Xfolders(
 
 \item{writeCBCtable}{A logical value indicating whether to write out a list of cell barcodes (CBC) as a tsv file. Default: \code{TRUE}.}
 
-\item{sort_alphanumeric}{sort files alphanumeric? Default: \code{TRUE}.}
+\item{sort_alphanumeric}{Sort files alphanumerically? Default: \code{TRUE}.}
 
 \item{save_empty_droplets}{save empty droplets? Default: \code{TRUE}.}
 

--- a/man/calculateAverageMetaData.Rd
+++ b/man/calculateAverageMetaData.Rd
@@ -29,7 +29,7 @@ Defaults to list('median' = median, 'mean' = mean).}
 \item{verbose}{Logical flag indicating whether to print detailed information about the metrics
 calculation process. Defaults to TRUE.}
 
-\item{max.categ}{max number of groups in ident.}
+\item{max.categ}{Maximum number of groups in ident.}
 }
 \value{
 A list containing data frames with calculated metrics for each specified metadata feature,

--- a/man/getCellIDs.from.meta.Rd
+++ b/man/getCellIDs.from.meta.Rd
@@ -18,7 +18,7 @@ getCellIDs.from.meta(
 
 \item{obj}{The Seurat object from which to retrieve the cell IDs. Default: combined.obj.}
 
-\item{inverse}{A boolean value indicating whether to inverse the match, i.e., retrieve cell IDs that do not match the provided list of ident_values. Default: \code{FALSE}.}
+\item{inverse}{A boolean value indicating whether to invert the match, i.e., retrieve cell IDs that do not match the provided list of ident_values. Default: \code{FALSE}.}
 }
 \value{
 A vector of cell IDs that match (or don't match, if \code{inverse = TRUE}) the provided list of values.

--- a/man/getMetadataColumn.Rd
+++ b/man/getMetadataColumn.Rd
@@ -11,7 +11,7 @@ getMetadataColumn(col = "batch", obj = combined.obj, as_numeric = FALSE)
 
 \item{obj}{A Seurat object from which the metadata column will be retrieved. Default: combined.obj.}
 
-\item{as_numeric}{A logical flag indicating whether the returned values should be converted to numeric format. Default: \code{FALSE}. (FALSE).}
+\item{as_numeric}{A logical flag indicating whether the returned values should be converted to numeric format. Default: \code{FALSE}.}
 }
 \value{
 A named vector containing the values from the specified metadata column. If 'as_numeric' is TRUE, the values are converted to numeric format.

--- a/man/plot.UMAP.tSNE.sidebyside.Rd
+++ b/man/plot.UMAP.tSNE.sidebyside.Rd
@@ -17,7 +17,7 @@
   pt_size = 0.5,
   name.suffix = NULL,
   width = hA4,
-  heigth = 1.75 * wA4,
+  height = 1.75 * wA4,
   filetype = "pdf",
   ...
 )
@@ -47,7 +47,7 @@
 
 \item{width}{Width of the plot. Default: hA4}
 
-\item{heigth}{Height of the plot. Default: 1.75 * wA4}
+\item{height}{Height of the plot. Default: 1.75 * wA4}
 
 \item{filetype}{Filetype to save plot as. Default: 'pdf'}
 

--- a/man/plotGeneExpressionInBackgroundHist.Rd
+++ b/man/plotGeneExpressionInBackgroundHist.Rd
@@ -33,7 +33,7 @@ Default: "data".}
 \item{...}{Any other parameter that can be passed to the internally called functions.}
 }
 \description{
-Shows a comparison of the expression level of the chose gene to all genes.
+Shows a comparison of the expression level of the chosen gene to all genes.
 Very useful to see if the gene has a meaningful expression level. This function generates a
 histogram to visualize the expression level distribution of a specified gene across all cells in
 a Seurat object. It highlights the position of the gene of interest within the overall distribution.


### PR DESCRIPTION
## Summary
- Correct parameter descriptions in metadata helpers
- Fix spelling and argument names in less-used utilities
- Clarify histogram documentation wording

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_6894b38204e4832ca125c994e9de1838