### PR TITLE
fix spelling mistakes

### DIFF
--- a/Development/Functions/Cluster.Auto-naming.DE.R
+++ b/Development/Functions/Cluster.Auto-naming.DE.R
@@ -31,7 +31,7 @@ Add.DE.combined.score <- function(df=df.markers, p_val_min=1e-25, pval_scaling =
 
 
 # ------------------------------------------------------------------------------------
-StoreTop25Markers <- function(obj = combined.obj # Save the top 25 makers based on `avg_log2FC` output table of `FindAllMarkers()` (df_markers) under `@misc$df.markers$res...`. By default, it rounds up insignificant digits up to 3.
+StoreTop25Markers <- function(obj = combined.obj # Save the top 25 markers based on `avg_log2FC` output table of `FindAllMarkers()` (df_markers) under `@misc$df.markers$res...`. By default, it rounds up insignificant digits up to 3.
                               , df_markers = df.markers, res = 0.5) {
   top25.markers <-
     df_markers %>%

--- a/Development/Functions/Metadata.manipulation.R
+++ b/Development/Functions/Metadata.manipulation.R
@@ -401,7 +401,7 @@ recallAllGenes <- function(obj = combined.obj) { # all.genes set by calc.q90.Exp
     all.genes <- obj@misc$all.genes
     print(head(unlist(all.genes)))
     ww.assign_to_global(name = "all.genes", value = all.genes)
-  } else {print("variable 'all.genes' exits in the global namespace")}
+  } else {print("variable 'all.genes' exists in the global namespace")}
 }
 # recallAllGenes(); all.genes
 
@@ -411,13 +411,13 @@ recall.meta.tags.n.datasets <- function(obj = combined.obj) {
     n.datasets <- obj@misc$n.datasets
     print(head(unlist(n.datasets)))
     ww.assign_to_global(name = "n.datasets", value = n.datasets)
-  } else {print("variable 'n.datasets' exits in the global namespace")}
+  } else {print("variable 'n.datasets' exists in the global namespace")}
 
   if (!exists('meta.tags')) {
     meta.tags <- obj@misc$meta.tags
     print(head(unlist(meta.tags)))
     ww.assign_to_global(name = "meta.tags", value = meta.tags)
-  } else {print("variable 'meta.tags' exits in the global namespace")}
+  } else {print("variable 'meta.tags' exists in the global namespace")}
 
 }
 # recall.n.datasets(); n.datasets
@@ -429,7 +429,7 @@ recall.parameters <- function(obj = combined.obj, overwrite = FALSE) {
   } else {
     p <- obj@misc$'p'
     print(head(p))
-    if (exists('p')) iprint("variable 'p' exits in the global namespace:");
+    if (exists('p')) iprint("variable 'p' exists in the global namespace:");
 
     if (!exists('p') | (exists('p') & overwrite == TRUE) ) {
       ww.assign_to_global(name = "p", value = p); print("Overwritten.")
@@ -447,7 +447,7 @@ recall.genes.ls<- function(obj = combined.obj) { # genes.ls
     genes.ls <- obj@misc$genes.ls
     print(head(unlist(genes.ls)))
     ww.assign_to_global(name = "genes.ls", value = genes.ls)
-  } else {print("variable 'genes.ls' exits in the global namespace")}
+  } else {print("variable 'genes.ls' exists in the global namespace")}
 }
 # recall.genes.ls(); genes.ls
 

--- a/Development/Functions/Plotting.dim.reduction.2D.R
+++ b/Development/Functions/Plotting.dim.reduction.2D.R
@@ -11,7 +11,7 @@ library(plotly)
 try(source("https://raw.githubusercontent.com/vertesy/ggExpressDev/main/ggExpress.functions.R"), silent = T)
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 

--- a/Development/Functions/Plotting.dim.reduction.3D.R
+++ b/Development/Functions/Plotting.dim.reduction.3D.R
@@ -11,7 +11,7 @@ try(library(MarkdownReportsDev), silent = T)
 try(library(htmlwidgets), silent = T)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 

--- a/Development/Functions/Plotting.statistics.and.QC.R
+++ b/Development/Functions/Plotting.statistics.and.QC.R
@@ -12,7 +12,7 @@ require(ggplot2)
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # PCA percent of variation associated with each PC ------------------------------------------------------------

--- a/Development/Functions/deprecated/Cell.Fractions.Old.R
+++ b/Development/Functions/deprecated/Cell.Fractions.Old.R
@@ -8,7 +8,7 @@
 require(Seurat)
 require(ggplot2)
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # sgCellFractionsBarplot.Mseq ------------------------------------------------------------------------

--- a/Development/Seurat.Utils.orig.R
+++ b/Development/Seurat.Utils.orig.R
@@ -31,7 +31,7 @@ Add.DE.combined.score <- function(df=df.markers, p_val_min=1e-25, pval_scaling =
 
 
 # ------------------------------------------------------------------------------------
-StoreTop25Markers <- function(obj = combined.obj # Save the top 25 makers based on `avg_log2FC` output table of `FindAllMarkers()` (df_markers) under `@misc$df.markers$res...`. By default, it rounds up insignificant digits up to 3.
+StoreTop25Markers <- function(obj = combined.obj # Save the top 25 markers based on `avg_log2FC` output table of `FindAllMarkers()` (df_markers) under `@misc$df.markers$res...`. By default, it rounds up insignificant digits up to 3.
                               , df_markers = df.markers, res = 0.5) {
   top25.markers <-
     df_markers %>%
@@ -974,7 +974,7 @@ recallAllGenes <- function(obj = combined.obj) { # all.genes set by calc.q90.Exp
     all.genes <- obj@misc$all.genes
     print(head(unlist(all.genes)))
     ww.assign_to_global(name = "all.genes", value = all.genes)
-  } else {print("variable 'all.genes' exits in the global namespace")}
+  } else {print("variable 'all.genes' exists in the global namespace")}
 }
 # recallAllGenes(); all.genes
 
@@ -984,13 +984,13 @@ recall.meta.tags.n.datasets <- function(obj = combined.obj) {
     n.datasets <- obj@misc$n.datasets
     print(head(unlist(n.datasets)))
     ww.assign_to_global(name = "n.datasets", value = n.datasets)
-  } else {print("variable 'n.datasets' exits in the global namespace")}
+  } else {print("variable 'n.datasets' exists in the global namespace")}
 
   if (!exists('meta.tags')) {
     meta.tags <- obj@misc$meta.tags
     print(head(unlist(meta.tags)))
     ww.assign_to_global(name = "meta.tags", value = meta.tags)
-  } else {print("variable 'meta.tags' exits in the global namespace")}
+  } else {print("variable 'meta.tags' exists in the global namespace")}
 
 }
 # recall.n.datasets(); n.datasets
@@ -1002,7 +1002,7 @@ recall.parameters <- function(obj = combined.obj, overwrite = FALSE) {
   } else {
     p <- obj@misc$'p'
     print(head(p))
-    if (exists('p')) iprint("variable 'p' exits in the global namespace:");
+    if (exists('p')) iprint("variable 'p' exists in the global namespace:");
 
     if (!exists('p') | (exists('p') & overwrite == TRUE) ) {
       ww.assign_to_global(name = "p", value = p); print("Overwritten.")
@@ -1020,7 +1020,7 @@ recall.genes.ls<- function(obj = combined.obj) { # genes.ls
     genes.ls <- obj@misc$genes.ls
     print(head(unlist(genes.ls)))
     ww.assign_to_global(name = "genes.ls", value = genes.ls)
-  } else {print("variable 'genes.ls' exits in the global namespace")}
+  } else {print("variable 'genes.ls' exists in the global namespace")}
 }
 # recall.genes.ls(); genes.ls
 
@@ -1421,7 +1421,7 @@ aux.plotAllMseqBCs <- function(bar.table = bar.table[,1:96], barcodes.used = BCs
 # try(source("https://raw.githubusercontent.com/vertesy/ggExpressDev/main/ggExpress.functions.R"), silent = T)
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 
@@ -1811,7 +1811,7 @@ getDiscretePalette <- function(ident.used = GetClusteringRuns()[1]
 # try(library(htmlwidgets), silent = T)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 
@@ -2197,7 +2197,7 @@ PlotFilters <- function(ls.obj = ls.Seurat # Plot filtering threshold and distri
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # PCA percent of variation associated with each PC ------------------------------------------------------------

--- a/Development/old/00.Load.Seurat.Utils.LOCAL.R
+++ b/Development/old/00.Load.Seurat.Utils.LOCAL.R
@@ -27,5 +27,5 @@ try(source('~/GitHub/TheCorvinas/R/GO-scoring/Seurat.gene.sets.and.GO.terms.R'))
 
 # Requirements ------------------------
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")

--- a/Development/old/00.Load.Seurat.Utils.WEB.R
+++ b/Development/old/00.Load.Seurat.Utils.WEB.R
@@ -25,5 +25,5 @@ sourceGitHub("Seurat.gene.sets.and.GO.terms.R", repo = "TheCorvinas", folder = "
 
 # Requirements ------------------------
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")

--- a/Example.usage/Visualize.Gene.expression.v2.R
+++ b/Example.usage/Visualize.Gene.expression.v2.R
@@ -26,7 +26,7 @@ if (FALSE) {
 try (source('https://raw.githubusercontent.com/vertesy/CodeAndRoll/master/CodeAndRoll.R'),silent= F)
 try(source('https://raw.githubusercontent.com/vertesy/Seurat.utils/master/00.Load.Seurat.Utils.WEB.R'), silent =   T)
 try(source('https://raw.githubusercontent.com/vertesy/Seurat.multicore/master/00.Load.Seurat3.Multicore.R'), silent=T)
-# If it fails, see alternaitve at the end
+# If it fails, see alternative at the end
 
 require('MarkdownReportsDev')
 # If installation of MarkdownReportsDev did not work:
@@ -120,10 +120,10 @@ ClassicMarkers = c(
 )
 
 
-# Alternaitve for SEURAT.UTILS - You can try to load each script individually ------------------------
+# Alternative for SEURAT.UTILS - You can try to load each script individually ------------------------
 if (FALSE) {
   "SEURAT.UTILS components"
-  "You probably dont need all for your work"
+  "You probably don't need all for your work"
   try (source("https://raw.githubusercontent.com/vertesy/Seurat.utils/master/Seurat.update.gene.symbols.HGNC.R"))
   try (source("https://raw.githubusercontent.com/vertesy/Seurat.utils/master/metadata.manipulation.R"))
   try (source("https://raw.githubusercontent.com/vertesy/Seurat.utils/master/plotting.dim.reduction.2D.R"))
@@ -138,10 +138,10 @@ if (FALSE) {
 
 }
 
-# Alternaitve for SEURAT.MULTICORE - You can try to load each script individually ------------------------
+# Alternative for SEURAT.MULTICORE - You can try to load each script individually ------------------------
 if (FALSE) {
   " SEURAT.MULTICORE components"
-  "You probably dont need these at all for your work"
+  "You probably don't need these at all for your work"
   try(source("https://raw.githubusercontent.com/vertesy/Seurat.multicore/master/Seurat3.Multicore.Read.Write.R"))
   try(source("https://raw.githubusercontent.com/vertesy/Seurat.multicore/master/Seurat3.Multicore.Generic.Functions.R"))
 

--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -1821,7 +1821,7 @@ recall.all.genes <- function(obj = combined.obj, overwrite = FALSE) {
       MarkdownHelpers::ww.assign_to_global(name = "all.genes", value = all.genes, verbose = FALSE)
       message("all.genes is now (re)defined in the global environment.")
     } else {
-      message("  ->   Variable 'all.genes' exits in the global namespace, and overwrite is: FALSE")
+      message("  ->   Variable 'all.genes' exists in the global namespace, and overwrite is: FALSE")
     }
   } else {
     message("  ->   Slot 'all.genes' does not exist in obj@misc.")
@@ -1901,7 +1901,7 @@ recall.parameters <- function(obj = combined.obj, overwrite = FALSE) {
 
   if ("p" %in% names(obj@misc)) {
     p_found <- exists("p", envir = .GlobalEnv)
-    if (p_found) message("  ->   Variable 'p' exits in the global namespace.")
+    if (p_found) message("  ->   Variable 'p' exists in the global namespace.")
 
     if (!p_found | (p_found & overwrite == TRUE)) {
       MarkdownHelpers::ww.assign_to_global(name = "p", value = obj@misc$"p", verbose = FALSE)
@@ -1937,7 +1937,7 @@ recall.genes.ls <- function(obj = combined.obj, overwrite = FALSE) { # genes.ls
   obj <- ww.get.1st.Seur.element(obj)
 
   if ("genes.ls" %in% names(obj@misc)) {
-    if (!exists("genes.ls")) message("variable 'genes.ls' exits in the global namespace: ", head(p))
+    if (!exists("genes.ls")) message("variable 'genes.ls' exists in the global namespace: ", head(p))
 
     if (!exists("genes.ls") | (exists("genes.ls") & overwrite == TRUE)) {
       MarkdownHelpers::ww.assign_to_global(name = "genes.ls", value = obj@misc$"genes.ls")

--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -234,7 +234,7 @@ PlotFilters <- function(
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= FALSE) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= FALSE) # generic utilities functions
 # require('MarkdownReports') # require("devtools")
 
 # _________________________________________________________________________________________________
@@ -4023,7 +4023,7 @@ qqSaveGridA4 <- function(
 # try(library(htmlwidgets), silent = TRUE)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= TRUE) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= TRUE) # generic utilities functions
 # require('MarkdownReports') # require("devtools")
 
 


### PR DESCRIPTION
## Summary
- fix typos across development and example scripts
- ensure messages use correct spelling for 'exists' and similar

## Testing
- `R -q -e "devtools::document(); devtools::check()"` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68973c925d0c832c873f4f7b430e2779