### PR TITLE
Fix spelling errors in Seurat utils

### DIFF
--- a/Development/Functions/Metadata.manipulation.R
+++ b/Development/Functions/Metadata.manipulation.R
@@ -157,7 +157,7 @@ getCellIDs.from.meta <- function(ident = 'res.0.6', values = NA, obj=combined.ob
 # seu.add.meta.from.vector ------------------------------------------------------------------------
 seu.add.meta.from.vector <- function(obj = combined.obj, metaD.colname = metaD.colname.labeled, Label.per.cell=Cl.Label.per.cell ) { # Add a new metadata column to a Seurat  object
   obj@meta.data[, metaD.colname ] = Label.per.cell
-  iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
+  iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
   return(obj)
 }
 # combined.obj <- add.Cl.Label.2.Metadata(obj = combined.obj, metaD.colname = metaD.colname.labeled, Label.per.cell=Cl.Label.per.cell )
@@ -191,7 +191,7 @@ seu.map.and.add.new.ident.to.meta <- function(obj = combined.obj, ident.table = 
   # identity mapping ----------------
   new.ident <- translate(vec = as.character(Idents(obj)), old = ident.X, new = ident.Y)
   obj@meta.data[[metaD.colname]] = new.ident
-  iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:"); cat(paste0("\t", ident.Y, "\n"))
+  iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:"); cat(paste0("\t", ident.Y, "\n"))
 }
 # combined.obj <- seu.map.and.add.new.ident.to.meta(obj = combined.obj, ident.table = clusterIDs.GO.process)
 

--- a/Development/Functions/Plotting.dim.reduction.2D.R
+++ b/Development/Functions/Plotting.dim.reduction.2D.R
@@ -11,7 +11,7 @@ library(plotly)
 try(source("https://raw.githubusercontent.com/vertesy/ggExpressDev/main/ggExpress.functions.R"), silent = T)
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 

--- a/Development/Functions/Plotting.dim.reduction.3D.R
+++ b/Development/Functions/Plotting.dim.reduction.3D.R
@@ -11,7 +11,7 @@ try(library(MarkdownReportsDev), silent = T)
 try(library(htmlwidgets), silent = T)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 

--- a/Development/Functions/Plotting.statistics.and.QC.R
+++ b/Development/Functions/Plotting.statistics.and.QC.R
@@ -12,7 +12,7 @@ require(ggplot2)
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # PCA percent of variation associated with each PC ------------------------------------------------------------

--- a/Development/Functions/deprecated/Cell.Fractions.Old.R
+++ b/Development/Functions/deprecated/Cell.Fractions.Old.R
@@ -8,7 +8,7 @@
 require(Seurat)
 require(ggplot2)
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # sgCellFractionsBarplot.Mseq ------------------------------------------------------------------------

--- a/Development/Seurat.Utils.orig.R
+++ b/Development/Seurat.Utils.orig.R
@@ -730,7 +730,7 @@ getCellIDs.from.meta <- function(ident = 'res.0.6', values = NA, obj=combined.ob
 # seu.add.meta.from.vector ------------------------------------------------------------------------
 seu.add.meta.from.vector <- function(obj = combined.obj, metaD.colname = metaD.colname.labeled, Label.per.cell=Cl.Label.per.cell ) { # Add a new metadata column to a Seurat  object
   obj@meta.data[, metaD.colname ] = Label.per.cell
-  iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
+  iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
   return(obj)
 }
 # combined.obj <- add.Cl.Label.2.Metadata(obj = combined.obj, metaD.colname = metaD.colname.labeled, Label.per.cell=Cl.Label.per.cell )
@@ -764,7 +764,7 @@ seu.map.and.add.new.ident.to.meta <- function(obj = combined.obj, ident.table = 
   # identity mapping ----------------
   new.ident <- translate(vec = as.character(Idents(obj)), old = ident.X, new = ident.Y)
   obj@meta.data[[metaD.colname]] = new.ident
-  iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:"); cat(paste0("\t", ident.Y, "\n"))
+  iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:"); cat(paste0("\t", ident.Y, "\n"))
 }
 # combined.obj <- seu.map.and.add.new.ident.to.meta(obj = combined.obj, ident.table = clusterIDs.GO.process)
 
@@ -1421,7 +1421,7 @@ aux.plotAllMseqBCs <- function(bar.table = bar.table[,1:96], barcodes.used = BCs
 # try(source("https://raw.githubusercontent.com/vertesy/ggExpressDev/main/ggExpress.functions.R"), silent = T)
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 
@@ -1811,7 +1811,7 @@ getDiscretePalette <- function(ident.used = GetClusteringRuns()[1]
 # try(library(htmlwidgets), silent = T)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= T) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 
@@ -2197,7 +2197,7 @@ PlotFilters <- function(ls.obj = ls.Seurat # Plot filtering threshold and distri
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")
 
 # PCA percent of variation associated with each PC ------------------------------------------------------------

--- a/Development/old/00.Load.Seurat.Utils.LOCAL.R
+++ b/Development/old/00.Load.Seurat.Utils.LOCAL.R
@@ -27,5 +27,5 @@ try(source('~/GitHub/TheCorvinas/R/GO-scoring/Seurat.gene.sets.and.GO.terms.R'))
 
 # Requirements ------------------------
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")

--- a/Development/old/00.Load.Seurat.Utils.WEB.R
+++ b/Development/old/00.Load.Seurat.Utils.WEB.R
@@ -25,5 +25,5 @@ sourceGitHub("Seurat.gene.sets.and.GO.terms.R", repo = "TheCorvinas", folder = "
 
 # Requirements ------------------------
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= F) # generic utilities functions
 # require('MarkdownReportsDev') # require("devtools") # plotting related utilities functions # devtools::install_github(repo = "vertesy/MarkdownReportsDev")

--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -737,7 +737,7 @@ seu.map.and.add.new.ident.to.meta <- function(
   {
     new.ident <- CodeAndRoll2::translate(vec = as.character(Idents(obj)), old = ident.X, new = ident.Y)
     obj@meta.data[[metaD.colname]] <- new.ident
-    iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:")
+    iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:")
     cat(paste0("\t", ident.Y, "\n"))
   }
 }
@@ -1286,7 +1286,7 @@ heatmap_calc_clust_median <- function(
       plotname = FixPlotName(make.names(plot_name), suffix, "pdf")
     )
 
-    # Now plot correlation heatmap between the identites
+    # Now plot correlation heatmap between the identities
     corX <- cor(t(df_cluster_medians), method = "spearman")
     pl <- pheatmap::pheatmap(corX,
       main = paste0("Correlation between ", plot_name),

--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -2433,7 +2433,7 @@ RelabelSmallCategories <- function(obj, col_in, backup_col_name = ppp(col_in, "o
 #' where small, possibly unrepresentative clusters may remain.
 #'
 #' @param obj Seurat object from which small clusters will be removed. Default: `combined.obj`.
-#' @param identitites Vector of clustering identities to examine for small clusters;
+#' @param identities Vector of clustering identities to examine for small clusters;
 #' Default: `GetClusteringRuns(obj)`.
 #' @param max.cells Maximum number of cells a cluster can contain to still be considered for removal.
 #' Default: The lesser of 0.5% of the dataset or 10 cells.
@@ -2449,14 +2449,14 @@ RelabelSmallCategories <- function(obj, col_in, backup_col_name = ppp(col_in, "o
 #' @export
 removeResidualSmallClusters <- function(
     obj = combined.obj,
-    identitites = GetClusteringRuns(obj, pat = "*snn_res.[0-9].[0-9]$")[1:5],
+    identities = GetClusteringRuns(obj, pat = "*snn_res.[0-9].[0-9]$")[1:5],
     max.cells = max(round((ncol(obj)) / 2000), 5),
     plot.removed = TRUE) {
   #
   stopifnot(
     inherits(obj, "Seurat"),
-    is.character(identitites), length(identitites) > 0,
-    all(identitites %in% colnames(obj@meta.data)),
+    is.character(identities), length(identities) > 0,
+    all(identities %in% colnames(obj@meta.data)),
     is.numeric(max.cells), max.cells > 0,
     is.logical(plot.removed)
   )
@@ -2467,10 +2467,10 @@ removeResidualSmallClusters <- function(
 
 
   message("max.cells: ", max.cells, " | Scanning over these identities:")
-  small.clusters <- cells.to.remove <- CodeAndRoll2::list.fromNames(identitites)
+  small.clusters <- cells.to.remove <- CodeAndRoll2::list.fromNames(identities)
 
-  for (i in 1:length(identitites)) {
-    colX <- identitites[i]
+  for (i in 1:length(identities)) {
+    colX <- identities[i]
     print(colX)
     tbl <- table(META[[colX]])
 
@@ -2485,9 +2485,9 @@ removeResidualSmallClusters <- function(
 
     all.cells.2.remove <- unique(unlist(cells.to.remove))
     if (plot.removed) {
-      SBT <- paste(length(all.cells.2.remove), "cells removed from small clusters across", length(identitites), "identities.")
+      SBT <- paste(length(all.cells.2.remove), "cells removed from small clusters across", length(identities), "identities.")
       pobj <- clUMAP(
-        obj = obj, ident = identitites[i],
+        obj = obj, ident = identities[i],
         sub = SBT, caption = NULL,
         cells.highlight = all.cells.2.remove
       )
@@ -2591,7 +2591,7 @@ removeClustersAndDropLevels <- function(ls_obj,
   for (index in indices) {
     dataset_name <- object_names[index]
     obj <- ls_obj[[dataset_name]]
-    obj <- removeResidualSmallClusters(obj = obj, identitites = GetClusteringRuns(obj), ...)
+    obj <- removeResidualSmallClusters(obj = obj, identities = GetClusteringRuns(obj), ...)
     obj <- dropLevelsSeurat(obj)
     ls_obj[[dataset_name]] <- obj
   }

--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -234,7 +234,7 @@ PlotFilters <- function(
 # tools for tools::toTitleCase
 
 # May also require
-# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= FALSE) # generic utilities funtions
+# try (source('/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= FALSE) # generic utilities functions
 # require('MarkdownReports') # require("devtools")
 
 # _________________________________________________________________________________________________
@@ -1197,7 +1197,7 @@ scBarplot.CellsPerCluster <- function(
 
   SBT <- pc_TRUE(nr.cells.per.cl < min.cells,
     NumberAndPC = TRUE,
-    suffix = paste("of identites are below:", min.cells, "cells, or", percentage_formatter(min.PCT.cells), "of all cells.")
+    suffix = paste("of identities are below:", min.cells, "cells, or", percentage_formatter(min.PCT.cells), "of all cells.")
   )
 
   pl <- ggExpress::qbarplot(cell.per.cluster,
@@ -4023,7 +4023,7 @@ qqSaveGridA4 <- function(
 # try(library(htmlwidgets), silent = TRUE)
 
 # May also require
-# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= TRUE) # generic utilities funtions
+# try (source('~/GitHub/Packages/CodeAndRoll/CodeAndRoll.R'),silent= TRUE) # generic utilities functions
 # require('MarkdownReports') # require("devtools")
 
 

--- a/R/Seurat.utils.less.used.R
+++ b/R/Seurat.utils.less.used.R
@@ -1000,7 +1000,7 @@ plotClustSizeDistr <- function(
 #' seu.add.meta.from.vector <- function(obj = combined.obj, metaD.colname, Label.per.cell = Cl.Label.per.cell) {
 #'   .Deprecated("addMetaDataSafe")
 #'   obj@meta.data[, metaD.colname] <- Label.per.cell
-#'   iprint(metaD.colname, "contains the named identitites. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
+#'   iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:", unique(Label.per.cell))
 #'   return(obj)
 #' }
 #'

--- a/man/AutoNumber.by.PrinCurve.Rd
+++ b/man/AutoNumber.by.PrinCurve.Rd
@@ -20,11 +20,11 @@ AutoNumber.by.PrinCurve(
 
 \item{plotit}{Plot results (& show it), Default: \code{TRUE}.}
 
-\item{swap}{Swap Lambda paramter (multiplied with this) , Default: -1}
+\item{swap}{Swap Lambda parameter (multiplied with this) , Default: -1}
 
 \item{reduction}{UMAP, tSNE, or PCA (Dim. reduction to use), Default: 'umap'}
 
-\item{res}{Clustering resoluton to use, Default: 'integrated_snn_res.0.5'}
+\item{res}{Clustering resolution to use, Default: 'integrated_snn_res.0.5'}
 }
 \description{
 Relabel cluster numbers along the principal curve of 2 UMAP (or tSNE) dimensions. #

--- a/man/GetClusteringRuns.Rd
+++ b/man/GetClusteringRuns.Rd
@@ -14,7 +14,7 @@ GetClusteringRuns(
 \arguments{
 \item{obj}{Seurat object, Default: \code{combined.obj}}
 
-\item{res}{Clustering resoluton to use, Default: \code{FALSE}.}
+\item{res}{Clustering resolution to use, Default: \code{FALSE}.}
 
 \item{pat}{Pattern to match, Default: \verb{*snn_res.*[0-9]$}}
 

--- a/man/GetNamedClusteringRuns.Rd
+++ b/man/GetNamedClusteringRuns.Rd
@@ -16,7 +16,7 @@ GetNamedClusteringRuns(
 \arguments{
 \item{obj}{Seurat object, Default: \code{combined.obj}}
 
-\item{res}{Clustering resoluton to use, Default: c(FALSE, 0.5)\link{1}}
+\item{res}{Clustering resolution to use, Default: c(FALSE, 0.5)\link{1}}
 
 \item{topgene}{Match clustering named after top expressed gene (see vertesy/Seurat.pipeline/~Diff gene expr.), Default: \code{FALSE}.}
 

--- a/man/GetOrderedClusteringRuns.Rd
+++ b/man/GetOrderedClusteringRuns.Rd
@@ -13,7 +13,7 @@ GetOrderedClusteringRuns(
 \arguments{
 \item{obj}{Seurat object, Default: \code{combined.obj}.}
 
-\item{res}{Clustering resoluton to use, Default: \code{FALSE}.}
+\item{res}{Clustering resolution to use, Default: \code{FALSE}.}
 
 \item{pat}{Pattern to match, Default: '\emph{snn_res.}\link{0,1}\.\link{0-9}\.ordered$'}
 }

--- a/man/removeResidualSmallClusters.Rd
+++ b/man/removeResidualSmallClusters.Rd
@@ -6,7 +6,7 @@
 \usage{
 removeResidualSmallClusters(
   obj = combined.obj,
-  identitites = GetClusteringRuns(obj, pat = "*snn_res.[0-9].[0-9]$")[1:5],
+  identities = GetClusteringRuns(obj, pat = "*snn_res.[0-9].[0-9]$")[1:5],
   max.cells = max(round((ncol(obj))/2000), 5),
   plot.removed = TRUE
 )
@@ -14,7 +14,7 @@ removeResidualSmallClusters(
 \arguments{
 \item{obj}{Seurat object from which small clusters will be removed. Default: \code{combined.obj}.}
 
-\item{identitites}{Vector of clustering identities to examine for small clusters;
+\item{identities}{Vector of clustering identities to examine for small clusters;
 Default: \code{GetClusteringRuns(obj)}.}
 
 \item{max.cells}{Maximum number of cells a cluster can contain to still be considered for removal.


### PR DESCRIPTION
## Summary
- Correct misspelling of `identitites` and `identites` to `identities`
- Fix documentation typos like `paramter` and `resoluton`
- Replace `funtions` with `functions` in code comments

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973c925d0c832c873f4f7b430e2779