### PR TITLE
Fix metadata column matching check in getMetaColnames

### DIFF
--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -90,7 +90,7 @@ getMetaColnames <- function(obj = combined.obj,
   matchedColnames <- grep(pattern = pattern, x = colnames(obj@meta.data), value = TRUE)
 
   # Output assertion
-  if (is.null(matchedColnames)) {
+  if (length(matchedColnames) == 0) {
     warning("No matching metadata!", immediate. = TRUE)
   } else {
     message(length(matchedColnames), " columns matching pattern '", pattern, "'.")


### PR DESCRIPTION
## Summary
- Correct metadata column match check to handle empty results and warn when no matches are found.

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(failed: command not found: R)*
- `apt-get update` *(failed: repository InRelease not signed)*
- `apt-get install -y r-base` *(failed: Unable to locate package r-base)*

------
https://chatgpt.com/codex/tasks/task_e_68973d28629c832caf7ef56acb314641