### PR TITLE
Apply suffix when adding translated metadata

### DIFF
--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -47,7 +47,7 @@ addTranslatedMetadata <- function(obj = combined.obj,
   stopifnot(
     is(obj, "Seurat"),
     is.character(orig.ident) && length(orig.ident) == 1,
-    is.character(suffix) | is.null(suffix),
+    is.vector(suffix) | is.null(suffix),
     "Not a named vec was provided!" = !is.null(names(translation_as_named_vec))
   )
 

--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -19,15 +19,15 @@
 #'
 #' @description
 #' This function translates a specified metadata vector in a Seurat object using a named vector of old
-#' and new values and adds it to the Seurat object with a specified suffix. The function also generates
-#' UMAP plots for the new metadata.
+#' and new values and adds it to the Seurat object. A suffix can optionally be appended to the name of
+#' the newly created metadata column. The function also generates UMAP plots for the new metadata.
 #'
 #' @param obj A Seurat object to be updated. Default: combined.obj.
 #' @param orig.ident A character string specifying the original metadata to be translated. Default: "RNA_snn_res.0.4".
 #' @param translation_as_named_vec A named vector where names are old values and values are new translations. Default: None.
-#' @param new_col_name A character string specifying the name of the new metadata column. Default: "translation_as_named_vec".
+#' @param new_col_name A character string specifying the base name of the new metadata column.
 # #' @param NA.as.character A logical indicating whether to convert NAs to character. Default: TRUE.
-#' @param suffix A character string specifying the suffix for the new metadata column name. Default: ".".
+#' @param suffix A character string appended to `new_col_name` to form the final metadata column name. Default: `NULL`.
 #' @param plot A logical indicating whether to plot the UMAP for the new metadata. Default: FALSE.
 #'
 #' @return An updated Seurat object.
@@ -44,14 +44,20 @@ addTranslatedMetadata <- function(obj = combined.obj,
                                   plot = FALSE,
                                   ...) {
   # Input assertions
-  stopifnot(is(obj, "Seurat"),
+  stopifnot(
+    is(obj, "Seurat"),
     is.character(orig.ident) && length(orig.ident) == 1,
     is.character(suffix) | is.null(suffix),
     "Not a named vec was provided!" = !is.null(names(translation_as_named_vec))
   )
+
+  # Allow appending a suffix to the metadata column name
+  if (!is.null(suffix)) {
+    new_col_name <- paste0(new_col_name, suffix)
+  }
   message("new_col_name: ", new_col_name)
 
-  # Translate metadata
+  # Translate metadata and store under the new column name
   obj@meta.data[[new_col_name]] <- new <- CodeAndRoll2::translate(
     vec = as.character(obj@meta.data[[orig.ident]]),
     old = names(translation_as_named_vec),

--- a/man/addTranslatedMetadata.Rd
+++ b/man/addTranslatedMetadata.Rd
@@ -19,11 +19,11 @@ addTranslatedMetadata(
 
 \item{orig.ident}{A character string specifying the original metadata to be translated. Default: "RNA_snn_res.0.4".}
 
-\item{translation_as_named_vec}{A named vector where names are old values and values are new translations. Default: None.}
+\item{translation_as_named_vec}{A named vector where names are old values and values are new translations.}
 
-\item{new_col_name}{A character string specifying the name of the new metadata column. Default: "translation_as_named_vec".}
+\item{new_col_name}{A character string specifying the base name of the new metadata column.}
 
-\item{suffix}{A character string specifying the suffix for the new metadata column name. Default: ".".}
+\item{suffix}{A character string appended to \code{new_col_name} to form the final metadata column name. Default: \code{NULL}.}
 
 \item{plot}{A logical indicating whether to plot the UMAP for the new metadata. Default: FALSE.}
 }
@@ -32,6 +32,6 @@ An updated Seurat object.
 }
 \description{
 This function translates a specified metadata vector in a Seurat object using a named vector of old
-and new values and adds it to the Seurat object with a specified suffix. The function also generates
-UMAP plots for the new metadata.
+and new values and adds it to the Seurat object. A suffix can optionally be appended to the name of
+the newly created metadata column. The function also generates UMAP plots for the new metadata.
 }


### PR DESCRIPTION
## Summary
- respect the `suffix` argument in `addTranslatedMetadata` to append text to the created metadata column
- document the `suffix` parameter and updated behavior

## Testing
- `R -q -e "devtools::document(); devtools::check()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b886c3c68832cb117b9e44845cd54