### PR TITLE
Fix PctCellsExpressingGenes documentation examples

### DIFF
--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -795,15 +795,14 @@ PctCellsAboveX <- function(
 #' \dontrun{
 #' # Load the Seurat object (example)
 #' library(Seurat)
-#' `combined.obj <- readRDS("path/to/your/seurat_object.rds")`
+#' combined.obj <- readRDS("path/to/your/seurat_object.rds")
 #'
-#' # Define genes of interest
 #' # Define genes of interest
 #' genes <- c("TOP2A", "MAP2")
 #' # Call the function
 #' PctCellsExpressingGenes(genes = genes, obj = combined.obj)
 #' # Call the function with ident
-#' #' PctCellsExpressingGenes(genes = genes, obj = combined.obj, ident = "cluster")
+#' PctCellsExpressingGenes(genes = genes, obj = combined.obj, ident = "cluster")
 #' }
 #'
 #' @importFrom Seurat GetAssayData

--- a/man/PctCellsExpressingGenes.Rd
+++ b/man/PctCellsExpressingGenes.Rd
@@ -41,15 +41,14 @@ object as input.
 \dontrun{
 # Load the Seurat object (example)
 library(Seurat)
-`combined.obj <- readRDS("path/to/your/seurat_object.rds")`
+combined.obj <- readRDS("path/to/your/seurat_object.rds")
 
-# Define genes of interest
 # Define genes of interest
 genes <- c("TOP2A", "MAP2")
 # Call the function
 PctCellsExpressingGenes(genes = genes, obj = combined.obj)
 # Call the function with ident
-#' PctCellsExpressingGenes(genes = genes, obj = combined.obj, ident = "cluster")
+PctCellsExpressingGenes(genes = genes, obj = combined.obj, ident = "cluster")
 }
 
 }


### PR DESCRIPTION
### Motivation
- The roxygen examples for `PctCellsExpressingGenes()` contained an invalid backtick-wrapped assignment, duplicated comment lines, and an accidental nested `#'` before the `ident` example, which breaks readability and the intended example usage.
- The example must remain inside `\dontrun{}` because it requires a user-provided Seurat object and should present valid R syntax to users and to `roxygen2` when generating the Rd file.

### Description
- Replace the backtick-wrapped assignment with a normal R assignment in the roxygen block: `combined.obj <- readRDS("path/to/your/seurat_object.rds")`.
- Remove the duplicated comment line and remove the accidental nested `#'` so the `ident` example appears as `PctCellsExpressingGenes(genes = genes, obj = combined.obj, ident = "cluster")` inside the existing `\dontrun{}`.
- Update the generated man page `man/PctCellsExpressingGenes.Rd` to reflect the corrected example so the documentation is consistent with the roxygen source.

### Testing
- Ran `git diff --check` and repository checks which reported no whitespace or diff issues (success).
- Attempted to regenerate documentation with `R -q -e "devtools::document()"`, but this failed because `R` is not available in the environment (failure).
- Attempted to install `r-base-core`/`r-cran-roxygen2` to run documentation generation, but `apt-get` failed due to repository errors (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb3f12f90832cb2533aa59da6703f)