### PR TITLE
Update roxygen, warning text, and input assertions for writeCombinedMetadataToTsvFromLsObj

### DIFF
--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -1121,17 +1121,28 @@ merge_seurat_metadata <- function(ls_obj, include_cols = NULL, exclude_cols = NU
 #'
 #' @examples
 #' # Assuming a list of Seurat objects with meta.data
-#' mergedMetaData <- writeMetadataToTsv(seuratObjectsList, cols.remove = c("column1", "column2"))
+#' mergedMetaData <- writeCombinedMetadataToTsvFromLsObj(
+#'   seuratObjectsList,
+#'   cols.remove = c("column1", "column2")
+#' )
 #'
 #' @note
 #' This function is intended for use with S4 objects that have a `@meta.data` slot.
-#' The function currently contains a `browser()` call for debugging purposes, which should be removed in production.
 #'
 #' @export
 writeCombinedMetadataToTsvFromLsObj <- function(ls.Obj, cols.remove = character(),
                                                 save_as_qs = TRUE, save_as_tsv = TRUE, ...) {
-  warning("writeMetadataToTsv is EXPERIMENTAL. It writes out subset of columns", immediate. = TRUE)
-  stopifnot(is.list(ls.Obj)) # Validate that input is a list
+  warning(
+    "writeCombinedMetadataToTsvFromLsObj is EXPERIMENTAL. It merges shared metadata columns and optionally writes QS and TSV files.",
+    immediate. = TRUE
+  )
+  # Validate collection, column selection, and output switches.
+  stopifnot(
+    is.list(ls.Obj),
+    is.character(cols.remove),
+    is.logical(save_as_qs), length(save_as_qs) == 1L, !is.na(save_as_qs),
+    is.logical(save_as_tsv), length(save_as_tsv) == 1L, !is.na(save_as_tsv)
+  )
 
   # Extract metadata from each object and remove specified columns
   metadataList <- lapply(ls.Obj, function(obj) {


### PR DESCRIPTION
### Motivation

- Clarify examples and documentation for `writeCombinedMetadataToTsvFromLsObj` by updating the roxygen example to call the current function name.  
- Remove a stale note about a leftover `browser()` call and make the experimental warning accurately describe current behavior.  
- Add compact input assertions to fail early on incorrect argument types and follow package coding conventions.

### Description

- Updated the roxygen `@examples` to call `writeCombinedMetadataToTsvFromLsObj(...)` instead of the obsolete name.  
- Removed the stale note about a `browser()` call from the roxygen block.  
- Rewrote the experimental `warning()` to name `writeCombinedMetadataToTsvFromLsObj` and to describe that it merges shared metadata columns and can write QS/TSV outputs.  
- Added a compact, combined `stopifnot()` assertion verifying `is.list(ls.Obj)`, `is.character(cols.remove)`, and that `save_as_qs`/`save_as_tsv` are scalar logicals and not `NA` as a concise input check.
- Did not edit `man/writeCombinedMetadataToTsvFromLsObj.Rd` by hand; the roxygen source in `R/Seurat.Utils.Metadata.R` was updated and documentation should be regenerated with roxygen in the implementation/CI step.

### Testing

- `git diff --check` was run and returned clean results.  
- The change was committed (`git commit`) successfully.  
- Attempted to run `devtools::document()` to regenerate `.Rd` files with roxygen, but `R` is not available in the environment so documentation regeneration was not performed and must be run in CI or locally before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb3e4cc08832ca9bd153227317f08)