### PR TITLE
Fix DatabaseLinke.R installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ devtools::install_github(repo = "vertesy/MarkdownReports", ref = "main", upgrade
 devtools::install_github(repo = "vertesy/ggExpress", ref = "main", upgrade = F)
 
 # Recommended
-devtools::install_github(repo = "vertesy/DatabaseLinke.R, ref = "main"", upgrade = F)
+devtools::install_github(repo = "vertesy/DatabaseLinke.R", ref = "main", upgrade = FALSE)
 
 # Install Seurat.utils
 devtools::install_github(repo = "vertesy/Seurat.utils", ref = "main", upgrade = F)


### PR DESCRIPTION
### Motivation
- Ensure the README installation example uses a correct `devtools::install_github()` call and a robust logical constant so users can install the recommended `DatabaseLinke.R` dependency without a syntax error.

### Description
- Update `README.md` to use `devtools::install_github(repo = "vertesy/DatabaseLinke.R", ref = "main", upgrade = FALSE)`, fixing the repository string and passing `ref = "main"` as a separate argument while replacing `F` with `FALSE`.

### Testing
- Ran `git diff --check` and a grep-based verification that the corrected command appears exactly once in `README.md`, both of which succeeded, and attempted `R -q -e` parsing which could not run because R is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb3cdd8d4832c8067331733ee5c8a)