### PR TITLE
Add gtools to package Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     ggpubr,
     ggrepel,
     gplots,
+    gtools,
     harmony,
     htmlwidgets,
     matrixStats,

--- a/Development/config.R
+++ b/Development/config.R
@@ -16,7 +16,7 @@ DESCRIPTION <- list(
     ReadWriter, MarkdownHelpers, MarkdownReports,
     plotly, qs, foreach, harmony, EnhancedVolcano, rstudioapi,
     RColorBrewer, SeuratObject, checkmate, fs, future,
-    ggplot2, gplots", # , grDevices
+    ggplot2, gplots, gtools", # , grDevices
   suggests = "clusterProfiler, enrichplot, DatabaseLinke.R, vroom",
   author.given = "Abel",
   author.family = "Vertesy",


### PR DESCRIPTION
### Motivation
- Ensure `gtools` is declared as a runtime dependency so functions relying on it are available when the package is used.

### Description
- Added `gtools` to the `Imports` field in `DESCRIPTION` and to the `imports` string in `Development/config.R` (modified files: `DESCRIPTION`, `Development/config.R`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb3ac377c832cb1fb4d76cc5d8c65)