### PR TITLE
Validate inputs and preserve matrix shape in PlotUpdateStats

### DIFF
--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -4515,8 +4515,9 @@ GetUpdateStats <- function(genes = HGNC.updated[[i]]) {
 #'
 #' @export
 PlotUpdateStats <- function(mat = UpdateStatMat, column.names = c("Updated (%)", "Updated (Nr.)")) { # Scatter plot of update stats.
-  stopifnot(column.names %in% colnames(UpdateStatMat))
-  HGNC.UpdateStatistics <- mat[, column.names]
+  # The plot labels below require exactly two columns from a rectangular input.
+  stopifnot(is.matrix(mat) || is.data.frame(mat), is.character(column.names), length(column.names) == 2L, all(column.names %in% colnames(mat)))
+  HGNC.UpdateStatistics <- mat[, column.names, drop = FALSE]
   HGNC.UpdateStatistics[, "Updated (%)"] <- 100 * HGNC.UpdateStatistics[, "Updated (%)"]
   colnames(HGNC.UpdateStatistics) <- c("Gene Symbols updated (% of Total Genes)", "Number of Gene Symbols updated")
   lll <- wcolorize(vector = rownames(HGNC.UpdateStatistics))


### PR DESCRIPTION
### Motivation
- Ensure `PlotUpdateStats` robustly validates its inputs and correctly handles both `matrix` and `data.frame` inputs while requiring exactly two columns for plotting.

### Description
- Add stricter input checks to `PlotUpdateStats` to require `mat` be a `matrix` or `data.frame`, `column.names` be a character vector of length 2, and that both names exist in `colnames(mat)`; use `drop = FALSE` when subsetting to preserve shape.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb3a0365c832c895608ec25b6ae43)