### PR TITLE
Add `save` parameter to `Convert10Xfolders` with validation and docs

### DIFF
--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -4567,12 +4567,12 @@ PlotUpdateStats <- function(mat = UpdateStatMat, column.names = c("Updated (%)",
 #' @param min.features An integer value specifying the minimum number of features. Default: 200.
 #' @param normalize_data Add normalized "data" layer?. Default: `TRUE`.
 #' @param updateHGNC A logical value indicating whether to update the HGNC. Default: `TRUE`.
-#' @param save Save .qs object? Default: `TRUE`.
 #' @param ShowStats A logical value indicating whether to show statistics. Default: `TRUE`.
 #' @param writeCBCtable A logical value indicating whether to write out a list of cell barcodes (CBC) as a tsv file. Default: `TRUE`.
 #' @param depth An integer value specifying the depth of scan (i.e., how many levels below the InputDir). Default: 2.
 #' @param sort_alphanumeric sort files alphanumeric? Default: `TRUE`.
 #' @param save_empty_droplets save empty droplets? Default: `TRUE`.
+#' @param save Save .qs object? Default: `TRUE`.
 #'
 #' @examples
 #' \dontrun{
@@ -4588,13 +4588,13 @@ Convert10Xfolders <- function(
     min.cells = 5, min.features = 200,
     normalize_data = TRUE,
     updateHGNC = TRUE, ShowStats = TRUE,
-    save = TRUE,
     writeCBCtable = TRUE,
     nthreads = .getNrCores(),
     preset = "high",
     ext = "qs",
     sort_alphanumeric = TRUE,
     save_empty_droplets = TRUE,
+    save = TRUE,
     ...) {
   stopifnot(
     is.character(InputDir), dir.exists(InputDir),

--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -4588,6 +4588,7 @@ Convert10Xfolders <- function(
     min.cells = 5, min.features = 200,
     normalize_data = TRUE,
     updateHGNC = TRUE, ShowStats = TRUE,
+    save = TRUE,
     writeCBCtable = TRUE,
     nthreads = .getNrCores(),
     preset = "high",
@@ -4598,7 +4599,8 @@ Convert10Xfolders <- function(
   stopifnot(
     is.character(InputDir), dir.exists(InputDir),
     is.logical(regex), is.character(folderPattern), is.character(suffix), is.numeric(depth),
-    is.numeric(min.cells), is.numeric(min.features), is.logical(updateHGNC), is.logical(ShowStats), is.logical(writeCBCtable),
+    is.numeric(min.cells), is.numeric(min.features), is.logical(updateHGNC), is.logical(ShowStats),
+    is.logical(save) && length(save) == 1L && !is.na(save), is.logical(writeCBCtable),
     is.logical(sort_alphanumeric)
   )
 

--- a/man/Convert10Xfolders.Rd
+++ b/man/Convert10Xfolders.Rd
@@ -15,6 +15,7 @@ Convert10Xfolders(
   normalize_data = TRUE,
   updateHGNC = TRUE,
   ShowStats = TRUE,
+  save = TRUE,
   writeCBCtable = TRUE,
   nthreads = .getNrCores(),
   preset = "high",
@@ -45,13 +46,13 @@ Convert10Xfolders(
 
 \item{ShowStats}{A logical value indicating whether to show statistics. Default: \code{TRUE}.}
 
+\item{save}{Save .qs object? Default: \code{TRUE}.}
+
 \item{writeCBCtable}{A logical value indicating whether to write out a list of cell barcodes (CBC) as a tsv file. Default: \code{TRUE}.}
 
 \item{sort_alphanumeric}{Sort files alphanumerically? Default: \code{TRUE}.}
 
 \item{save_empty_droplets}{save empty droplets? Default: \code{TRUE}.}
-
-\item{save}{Save .qs object? Default: \code{TRUE}.}
 }
 \description{
 This function takes a parent directory with a number of subfolders, each

--- a/man/Convert10Xfolders.Rd
+++ b/man/Convert10Xfolders.Rd
@@ -15,13 +15,13 @@ Convert10Xfolders(
   normalize_data = TRUE,
   updateHGNC = TRUE,
   ShowStats = TRUE,
-  save = TRUE,
   writeCBCtable = TRUE,
   nthreads = .getNrCores(),
   preset = "high",
   ext = "qs",
   sort_alphanumeric = TRUE,
   save_empty_droplets = TRUE,
+  save = TRUE,
   ...
 )
 }
@@ -46,13 +46,13 @@ Convert10Xfolders(
 
 \item{ShowStats}{A logical value indicating whether to show statistics. Default: \code{TRUE}.}
 
-\item{save}{Save .qs object? Default: \code{TRUE}.}
-
 \item{writeCBCtable}{A logical value indicating whether to write out a list of cell barcodes (CBC) as a tsv file. Default: \code{TRUE}.}
 
 \item{sort_alphanumeric}{Sort files alphanumerically? Default: \code{TRUE}.}
 
 \item{save_empty_droplets}{save empty droplets? Default: \code{TRUE}.}
+
+\item{save}{Save .qs object? Default: \code{TRUE}.}
 }
 \description{
 This function takes a parent directory with a number of subfolders, each


### PR DESCRIPTION
### Motivation
- Allow callers to control whether `.qs` objects are written by adding an explicit `save` parameter to `Convert10Xfolders` and ensure the value is validated.

### Description
- Add `save = TRUE` to the `Convert10Xfolders` function signature and update the generated Rd documentation to include the new `save` argument.
- Add a `stopifnot` check of `is.logical(save) && length(save) == 1L && !is.na(save)` to validate the new parameter.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb39b3084832c9c84eab4c1540e64)