### PR TITLE
Validate inputs and fix cell selection in Calc.Cor.Seurat

### DIFF
--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -3403,12 +3403,20 @@ Calc.Cor.Seurat <- function(
     max.cells = 40000,
     seed = p$"seed",
     digits = 2, obj = combined.obj) {
+  stopifnot(
+    inherits(obj, "Seurat"),
+    is.numeric(max.cells), length(max.cells) == 1L, !is.na(max.cells), is.finite(max.cells), max.cells > 0,
+    is.numeric(quantileX), length(quantileX) == 1L, !is.na(quantileX), is.finite(quantileX), quantileX >= 0, quantileX <= 1,
+    is.numeric(digits), length(digits) == 1L, !is.na(digits), is.finite(digits)
+  )
   expr.mat <- GetAssayData(slot = slot.use, assay = assay.use, object = obj)
   if (ncol(expr.mat) > max.cells) {
     set.seed(seed = seed)
     cells.use <- sample(x = colnames(expr.mat), size = max.cells)
   } else {
-    cells.use <- ncol(expr.mat)
+    # Retain every cell when downsampling is unnecessary.
+    cells.use <- colnames(expr.mat)
+    if (is.null(cells.use)) cells.use <- seq_len(ncol(expr.mat))
   }
 
   qname <- paste0("q", quantileX * 100)


### PR DESCRIPTION
### Motivation
- Ensure `Calc.Cor.Seurat` fails fast on invalid inputs to avoid obscure errors later during computation.
- Correct the cell selection logic so that when downsampling is unnecessary the actual cell identifiers are used instead of an integer count.

### Description
- Add input validation via `stopifnot(...)` to check that `obj` inherits from `Seurat` and that `max.cells`, `quantileX`, and `digits` are numeric and within expected ranges.
- Replace the previous `cells.use <- ncol(expr.mat)` with `cells.use <- colnames(expr.mat)` and fall back to `seq_len(ncol(expr.mat))` if column names are missing, with a comment explaining the intent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb38d4898832c95c095e9d2b09b4f)