### PR TITLE
Deprecate Convert10Xfolders.old in favor of Convert10Xfolders

### DIFF
--- a/R/Seurat.utils.less.used.R
+++ b/R/Seurat.utils.less.used.R
@@ -589,17 +589,11 @@ load10Xv3 <- function(dataDir, cellIDs = NULL, channelName = NULL, readArgs = li
 #' }
 #' @export
 Convert10Xfolders.old <- function(
-    InputDir,
-    folderPattern = c("filtered", "SoupX_decont")[1],
-    min.cells = 10, min.features = 200,
-    updateHGNC = TRUE, ShowStats = TRUE) {
-  # ... function body ...
-}
-
-Convert10Xfolders.old <- function(
     InputDir # Take a parent directory with a number of subfolders, each containing the standard output of 10X Cell Ranger. (1.) It loads the filtered data matrices; (2.) converts them to Seurat objects, and (3.) saves them as *.RDS files.
     , folderPattern = c("filtered", "SoupX_decont")[1],
     min.cells = 10, min.features = 200, updateHGNC = TRUE, ShowStats = TRUE) {
+  .Deprecated("Convert10Xfolders")
+
   fin <- list.dirs(InputDir, recursive = FALSE)
   fin <- CodeAndRoll2::grepv(x = fin, pattern = folderPattern, perl = FALSE)
 


### PR DESCRIPTION
### Motivation
- Mark `Convert10Xfolders.old` as deprecated and reduce confusion from a duplicate stub implementation by directing users to `Convert10Xfolders`.

### Description
- Add a call to `.Deprecated("Convert10Xfolders")` at the start of `Convert10Xfolders.old` and remove the earlier empty/stub definition so the active implementation warns users to use the newer function.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eb401b014832c9b75aa052df53135)