### PR TITLE
Declare qs2 dep + make sibling-package calls explicit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     pheatmap,
     plotly,
     princurve,
-    qs,
+    qs2,
     R.utils,
     RColorBrewer,
     readr,

--- a/Development/config.R
+++ b/Development/config.R
@@ -14,7 +14,7 @@ DESCRIPTION <- list(
     Matrix, matrixStats, princurve, pheatmap,
     R.utils, readr, reshape2, scales, SoupX, sparseMatrixStats, stringr, tibble, tictoc,
     ReadWriter, MarkdownHelpers, MarkdownReports,
-    plotly, qs, foreach, harmony, EnhancedVolcano, rstudioapi,
+    plotly, qs2, foreach, harmony, EnhancedVolcano, rstudioapi,
     RColorBrewer, SeuratObject, checkmate, fs, future,
     ggplot2, gplots, gtools", # , grDevices
   suggests = "clusterProfiler, enrichplot, DatabaseLinke.R, vroom",

--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -37,7 +37,7 @@
 addTranslatedMetadata <- function(obj = combined.obj,
                                   orig.ident = "RNA_snn_res.0.4",
                                   translation_as_named_vec,
-                                  new_col_name = substitute_deparse(translation_as_named_vec),
+                                  new_col_name = Stringendo::substitute_deparse(translation_as_named_vec),
                                   # NA.as.character = TRUE,
                                   suffix = NULL,
                                   plot = FALSE,
@@ -146,7 +146,7 @@ getMetadataColumn <- function(col = "batch", obj = combined.obj, as_numeric = FA
   stopifnot(col %in% colnames(obj@meta.data))
   if (v) message(substitute(obj), ", ", ncol(obj), " cells.")
 
-  x <- df.col.2.named.vector(df = obj@meta.data, col = col)
+  x <- CodeAndRoll2::df.col.2.named.vector(df = obj@meta.data, col = col)
   if (as_numeric) {
     as.numeric.wNames(x)
   } else {
@@ -341,7 +341,7 @@ calculatePercentageMatch <- function(
 #' }
 #' @export
 getMedianMetric.lsObj <- function(ls.obj = ls.Seurat, n.datasets = length(ls.Seurat), mColname = "percent.mito") {
-  medMetric <- vec.fromNames(names(ls.obj))
+  medMetric <- CodeAndRoll2::vec.fromNames(names(ls.obj))
   for (i in 1:n.datasets) {
     medMetric[i] <- median(ls.obj[[i]]@meta.data[, mColname])
   }
@@ -388,7 +388,7 @@ getCellIDs.from.meta <- function(ident = GetClusteringRuns()[1], # metadata colu
 
   if (inverse) cells.pass <- !cells.pass # optionally invert selection
 
-  iprint(sum(cells.pass), "cells found.") # report how many matched
+  Stringendo::iprint(sum(cells.pass), "cells found.") # report how many matched
   rownames(obj@meta.data)[which(cells.pass)] # return matching cell IDs
 }
 
@@ -421,13 +421,13 @@ addMetaDataSafe <- function(obj, metadata, col.name, overwrite = FALSE, verbose 
     "Column already exists" = ((!col.name %in% colnames(obj@meta.data)) | overwrite)
   )
   equal_length <- length(metadata) == ncol(obj)
-  iprint("strict", strict)
+  Stringendo::iprint("strict", strict)
   if (strict) stopifnot("Metadata or object too short" = equal_length)
 
   if (!is.null(names(metadata))) {
     if (verbose) {
-      iprint("cells in metadata:", head(names(metadata)), "...")
-      iprint("cells in object:", head(colnames(obj)), "...")
+      Stringendo::iprint("cells in metadata:", head(names(metadata)), "...")
+      Stringendo::iprint("cells in object:", head(colnames(obj)), "...")
     }
     if (strict) stopifnot(names(metadata) == colnames(obj))
   } else {
@@ -438,13 +438,13 @@ addMetaDataSafe <- function(obj, metadata, col.name, overwrite = FALSE, verbose 
   if (any(is.na(names(metadata)))) {
     warning("Metadata contains NA values.", immediate. = TRUE)
     metadata_orig <- metadata
-    metadata <- vec.fromNames(colnames(obj), fill = NA)
-    cells_found <- na.omit.strip(names(metadata_orig))
+    metadata <- CodeAndRoll2::vec.fromNames(colnames(obj), fill = NA)
+    cells_found <- CodeAndRoll2::na.omit.strip(names(metadata_orig))
     metadata[cells_found] <- metadata_orig[cells_found]
   }
 
   # Perform the operation
-  stopif(any(is.na(names(metadata))))
+  Stringendo::stopif(any(is.na(names(metadata))))
   obj <- Seurat::AddMetaData(object = obj, metadata = metadata, col.name = col.name)
 
   prefix <- paste("New column", col.name)
@@ -489,8 +489,8 @@ create.metadata.vector <- function(vec, obj = combined.obj, fill = NA,
   cells_in_both <- length(intersect(cells_in_vec, cells_in_obj))
   if (cells_in_both < min.intersect) {
     message(
-      ncol(obj), " cells in obj: ", kppc(cells_in_obj[1:3]), "\n",
-      length(vec), " cells in vec: ", kppc(cells_in_vec[1:3]), "\n",
+      ncol(obj), " cells in obj: ", Stringendo::kppc(cells_in_obj[1:3]), "\n",
+      length(vec), " cells in vec: ", Stringendo::kppc(cells_in_vec[1:3]), "\n",
       cells_in_both, " cells in both.\n"
     )
     stop("Intersection between vec and obj is less than min.intersect.")
@@ -501,7 +501,7 @@ create.metadata.vector <- function(vec, obj = combined.obj, fill = NA,
   cells.obj <- colnames(obj)
   cells.in.both <- intersect(cells.vec, cells.obj)
 
-  iprint(
+  Stringendo::iprint(
     length(cells.in.both), "cells in both;",
     length(cells.vec), "cells in vec;",
     length(cells.obj), "cells in obj",
@@ -568,7 +568,7 @@ addMetaFraction <- function(
     assay %in% Assays(obj), layer %in% Layers(obj)
   )
 
-  stopif(condition = isFALSE(gene.set) && isFALSE(gene.symbol.pattern), "Either gene.set OR gene.symbol.pattern has to be defined (!= FALSE).")
+  Stringendo::stopif(condition = isFALSE(gene.set) && isFALSE(gene.symbol.pattern), "Either gene.set OR gene.symbol.pattern has to be defined (!= FALSE).")
   if (!isFALSE(gene.set) && !isFALSE(gene.symbol.pattern) && verbose) print("Both gene.set AND gene.symbol.pattern are defined. Only using gene.set.")
 
   # if (!isFALSE(gene.set)) geneset <- check.genes(genes = gene.set, obj = obj)
@@ -584,7 +584,7 @@ addMetaFraction <- function(
   genes.expr <- GetAssayData(object = obj, assay = assay, layer = layer)[genes.matching, ]
   target_expr <- if (length(genes.matching) > 1) Matrix::colSums(genes.expr) else genes.expr
 
-  iprint(length(genes.matching), "genes found, eg:", head(genes.matching, 10))
+  Stringendo::iprint(length(genes.matching), "genes found, eg:", head(genes.matching, 10))
 
   obj <- AddMetaData(object = obj, metadata = target_expr / total_expr, col.name = col.name)
   colnames(obj@meta.data)
@@ -662,7 +662,7 @@ addGeneClassFractions <- function(obj,
       "VEGFA", "PDK1", "PGAM1", "IER2", "FOS", "BTG1", "EPB41L4A-AS1", "NPAS4", "HK2", "BNIP3L",
       "JUN", "ENO2", "GAPDH", "ANKRD37", "ALDOA", "GADD45G", "TXNIP"
     )
-    if (species == "mouse") HGA_MarkerGenes <- toSentence(HGA_MarkerGenes)
+    if (species == "mouse") HGA_MarkerGenes <- Stringendo::toSentence(HGA_MarkerGenes)
 
     if (!metaColnameExists(col_name = "percent.HGA", obj = obj)) {
       obj <- addMetaFraction(col.name = "percent.HGA", gene.set = HGA_MarkerGenes, obj = obj)
@@ -718,13 +718,13 @@ add.meta.tags <- function(list.of.tags = tags, obj = ls.Seurat[[1]], n = 1) { # 
 seu.add.meta.from.table <- function(obj = combined.obj, meta, suffix = ".fromMeta") { # Add multiple new metadata columns to a Seurat object from a table.
   NotFound <- setdiff(colnames(obj), rownames(meta))
   Found <- intersect(colnames(obj), rownames(meta))
-  if (length(NotFound)) iprint(length(NotFound), "cells were not found in meta, e.g.: ", trail(NotFound, N = 10))
+  if (length(NotFound)) Stringendo::iprint(length(NotFound), "cells were not found in meta, e.g.: ", CodeAndRoll2::trail(NotFound, N = 10))
 
   mCols.new <- colnames(meta)
   mCols.old <- colnames(obj@meta.data)
   overlap <- intersect(mCols.new, mCols.old)
   if (length(overlap)) {
-    iprint(length(overlap), "metadata columns already exist in the seurat object: ", overlap, ". These are tagged as: *", suffix)
+    Stringendo::iprint(length(overlap), "metadata columns already exist in the seurat object: ", overlap, ". These are tagged as: *", suffix)
     colnames(meta)[overlap] <- paste0(overlap, suffix)
   }
   mCols.add <- colnames(meta)
@@ -756,38 +756,38 @@ seu.add.meta.from.table <- function(obj = combined.obj, meta, suffix = ".fromMet
 seu.map.and.add.new.ident.to.meta <- function(
   obj = combined.obj, ident.table = clusterIDs.GO.process,
   orig.ident = Idents(obj),
-  metaD.colname = substitute_deparse(ident.table)
+  metaD.colname = Stringendo::substitute_deparse(ident.table)
 ) {
   # identities should match
   {
     Idents(obj) <- orig.ident
-    ident.vec <- df.col.2.named.vector(ident.table)
+    ident.vec <- CodeAndRoll2::df.col.2.named.vector(ident.table)
     ident.X <- names(ident.vec)
     ident.Y <- as.character(ident.vec)
     ident.Seu <- gtools::mixedsort(levels(Idents(obj)))
-    iprint("ident.Seu: ", ident.Seu)
+    Stringendo::iprint("ident.Seu: ", ident.Seu)
 
     OnlyInIdentVec <- setdiff(ident.X, ident.Seu)
     OnlyInSeuratIdents <- setdiff(ident.Seu, ident.X)
 
-    msg.IdentVec <- kollapse("Rownames of 'ident.table' have entries not found in 'Idents(obj)':",
+    msg.IdentVec <- Stringendo::kollapse("Rownames of 'ident.table' have entries not found in 'Idents(obj)':",
       OnlyInIdentVec, " not found in ", ident.Seu,
       collapseby = " "
     )
 
-    msg.Seu <- kollapse("Rownames of 'Idents(obj)' have entries not found in 'ident.table':",
+    msg.Seu <- Stringendo::kollapse("Rownames of 'Idents(obj)' have entries not found in 'ident.table':",
       OnlyInSeuratIdents, " not found in ", ident.X,
       collapseby = " "
     )
 
-    stopif(length(OnlyInIdentVec), message = msg.IdentVec)
-    stopif(length(OnlyInSeuratIdents), message = msg.Seu)
+    Stringendo::stopif(length(OnlyInIdentVec), message = msg.IdentVec)
+    Stringendo::stopif(length(OnlyInSeuratIdents), message = msg.Seu)
   }
   # identity mapping
   {
     new.ident <- CodeAndRoll2::translate(vec = as.character(Idents(obj)), old = ident.X, new = ident.Y)
     obj@meta.data[[metaD.colname]] <- new.ident
-    iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:")
+    Stringendo::iprint(metaD.colname, "contains the named identities. Use Idents(combined.obj) = '...'. The names are:")
     cat(paste0("\t", ident.Y, "\n"))
   }
 }
@@ -831,14 +831,14 @@ fix.orig.ident <- function(obj = merged.obj) {
 #' }
 seu.RemoveMetadata <- function(
   obj = combined.obj,
-  cols_remove = grepv(colnames(obj@meta.data), pattern = "^integr|^cl.names", perl = TRUE)
+  cols_remove = CodeAndRoll2::grepv(colnames(obj@meta.data), pattern = "^integr|^cl.names", perl = TRUE)
 ) {
   CNN <- colnames(obj@meta.data)
-  iprint("cols_remove:", cols_remove)
+  Stringendo::iprint("cols_remove:", cols_remove)
   print("")
   (cols_keep <- setdiff(CNN, cols_remove))
   obj@meta.data <- obj@meta.data[, cols_keep]
-  iprint("meta.data colnames kept:", colnames(obj@meta.data))
+  Stringendo::iprint("meta.data colnames kept:", colnames(obj@meta.data))
 
   return(obj)
 }
@@ -992,7 +992,7 @@ transferMetadata <- function(from, to,
     if (plotUMAP) {
       metaX <- getMetadataColumn(col = colnames_to[i], obj = to)
 
-      if (is.numeric(metaX) && nr.unique(metaX) > 10) {
+      if (is.numeric(metaX) && CodeAndRoll2::nr.unique(metaX) > 10) {
         x <- qUMAP(obj = to, feature = colnames_to[i], suffix = "transferred.ident", ...)
       } else {
         x <- clUMAP(obj = to, ident = colnames_to[i], suffix = "transferred.ident", ...)
@@ -1077,7 +1077,7 @@ merge_seurat_metadata <- function(ls_obj, include_cols = NULL, exclude_cols = NU
   merged_metadata <- dplyr::bind_rows(metadata_list)
 
   # Message all column names to console
-  message("Columns: ", kppc(colnames(merged_metadata)), "\n")
+  message("Columns: ", Stringendo::kppc(colnames(merged_metadata)), "\n")
   message(length(merged_metadata), " merged columns and ", nrow(merged_metadata), " cells from ", length(ls_obj), " objects.")
 
   return(merged_metadata)
@@ -1218,14 +1218,14 @@ plotMetadataCorHeatmap <- function(
   META <- obj@meta.data
   columns.found <- intersect(colnames(META), columns)
   columns.not.found <- setdiff(columns, colnames(META))
-  if (length(columns.not.found)) iprint("columns.not.found:", columns.not.found)
+  if (length(columns.not.found)) Stringendo::iprint("columns.not.found:", columns.not.found)
 
   META <- META[, columns.found]
 
   if (add_PCA) {
-    stopif(is.null(obj@reductions$"pca"), "PCA not found in @reductions.")
+    Stringendo::stopif(is.null(obj@reductions$"pca"), "PCA not found in @reductions.")
     main <- paste("Metadata and PC", cormethod, "correlations")
-    suffix <- FixPlotName(suffix, "w.PCA")
+    suffix <- Stringendo::FixPlotName(suffix, "w.PCA")
 
     PCs <- obj@reductions$pca@cell.embeddings
     stopifnot(nrow(META) == nrow(PCs))
@@ -1242,15 +1242,15 @@ plotMetadataCorHeatmap <- function(
       type = "full",
       ...
     )
-    ggExpress::qqSave(pl, fname = FixPlotName(make.names(main), suffix, "png"), also.pdf = TRUE, w = w, h = h)
+    ggExpress::qqSave(pl, fname = Stringendo::FixPlotName(make.names(main), suffix, "png"), also.pdf = TRUE, w = w, h = h)
   } else {
     pl <- pheatmap::pheatmap(corX,
       main = main, treeheight_row = 2, treeheight_col = 2,
       cutree_rows = n_cutree, cutree_cols = n_cutree
     )
-    wplot_save_pheatmap(
+    MarkdownReports::wplot_save_pheatmap(
       x = pl, width = w,
-      plotname = FixPlotName(make.names(main), suffix, "pdf")
+      plotname = Stringendo::FixPlotName(make.names(main), suffix, "pdf")
     )
   }
   print(pl)
@@ -1315,28 +1315,28 @@ heatmap_calc_clust_median <- function(
 
   if (!isFALSE(subset_ident_levels)) {
     stopifnot(all(subset_ident_levels %in% rownames(df_cluster_medians)))
-    suffix <- FixPlotName(suffix, "subset")
+    suffix <- Stringendo::FixPlotName(suffix, "subset")
     df_cluster_medians <- df_cluster_medians[subset_ident_levels, ]
   }
 
   if (scale) {
     df_cluster_medians <- scale(df_cluster_medians)
-    suffix <- sppp(suffix, "scaled")
+    suffix <- Stringendo::sppp(suffix, "scaled")
   }
 
   if (return_matrix) {
     return(df_cluster_medians)
   } else {
-    plot_name <- FixPlotName(plotname, suffix)
+    plot_name <- Stringendo::FixPlotName(plotname, suffix)
     pl <- pheatmap::pheatmap(df_cluster_medians,
       main = plot_name,
       cutree_rows = n_cut_row,
       cutree_cols = n_cut_col,
       ...
     )
-    wplot_save_pheatmap(
+    MarkdownReports::wplot_save_pheatmap(
       x = pl, width = w,
-      plotname = FixPlotName(make.names(plot_name), suffix, "pdf")
+      plotname = Stringendo::FixPlotName(make.names(plot_name), suffix, "pdf")
     )
 
     # Now plot correlation heatmap between the identities
@@ -1348,9 +1348,9 @@ heatmap_calc_clust_median <- function(
       cutree_rows = n_cut_row, cutree_cols = n_cut_col
     )
 
-    wplot_save_pheatmap(
+    MarkdownReports::wplot_save_pheatmap(
       x = pl, width = w,
-      plotname = FixPlotName(make.names(plot_name), suffix, "correlation.pdf")
+      plotname = Stringendo::FixPlotName(make.names(plot_name), suffix, "correlation.pdf")
     )
   }
 }
@@ -1407,11 +1407,11 @@ plotMetadataMedianFractionBarplot <- function(
     dplyr::summarize_all(median)
   )
   if (min.thr > 0) {
-    pass.cols <- colMax(mat.cluster.medians1[, -1]) > (min.thr / 100)
-    cols.OK <- which_names(pass.cols)
-    cols.FAIL <- which_names(!pass.cols)
-    subt <- paste(length(cols.FAIL), "classed do not reach", min.thr, "% :", kpps(cols.FAIL))
-    iprint(subt)
+    pass.cols <- CodeAndRoll2::colMax(mat.cluster.medians1[, -1]) > (min.thr / 100)
+    cols.OK <- CodeAndRoll2::which_names(pass.cols)
+    cols.FAIL <- CodeAndRoll2::which_names(!pass.cols)
+    subt <- paste(length(cols.FAIL), "classed do not reach", min.thr, "% :", Stringendo::kpps(cols.FAIL))
+    Stringendo::iprint(subt)
     mat.cluster.medians1 <- mat.cluster.medians1[, c(group.by, cols.OK)]
   }
 
@@ -1427,7 +1427,7 @@ plotMetadataMedianFractionBarplot <- function(
     position = position,
     title = main, subtitle = subt, ylab = ylab
   )
-  ggExpress::qqSave(pl, fname = ppp(make.names(main), "pdf"), w = w, h = h)
+  ggExpress::qqSave(pl, fname = Stringendo::ppp(make.names(main), "pdf"), w = w, h = h)
   pl
   if (return.matrix) mat.cluster.medians1 else pl
 }
@@ -1479,8 +1479,8 @@ plotMetadataCategPie <- function(
   categ_pivot <- table(obj[[metacol]])
   stopifnot(length(categ_pivot) < max.categs)
 
-  qpie(categ_pivot,
-    plotname = FixPlotName(make.names(plot_name)),
+  ggExpress::qpie(categ_pivot,
+    plotname = Stringendo::FixPlotName(make.names(plot_name)),
     both_pc_and_value = both_pc_and_value,
     LegendSide = LegendSide, labels = labels,
     LegendTitle = "", subtitle = subtitle,
@@ -1527,7 +1527,7 @@ renameAzimuthColumns <- function(obj, ref = c("humancortexref", "fetusref")[1],
   )
 
   ref <- sub(pattern = "ref", replacement = "", x = ref)
-  iprint(length(azim_cols), "azim_cols:", azim_cols)
+  Stringendo::iprint(length(azim_cols), "azim_cols:", azim_cols)
 
   # Extract the column names of meta.data
   meta_col_names <- colnames(obj@meta.data)
@@ -1536,13 +1536,13 @@ renameAzimuthColumns <- function(obj, ref = c("humancortexref", "fetusref")[1],
   for (azim_col in azim_cols) {
     if (azim_col %in% meta_col_names) {
       # Create the new column name by replacing "predicted." with the new prefix
-      new_col_name <- sub(pattern = "^predicted\\.", replacement = kpp(prefix, ref, ""), x = azim_col)
+      new_col_name <- sub(pattern = "^predicted\\.", replacement = Stringendo::kpp(prefix, ref, ""), x = azim_col)
       names(obj@meta.data)[names(obj@meta.data) == azim_col] <- new_col_name
     }
   }
 
   if ("mapping.score" %in% colnames(obj@meta.data)) {
-    names(obj@meta.data)[names(obj@meta.data) == "mapping.score"] <- kpp(prefix, ref, "mapping.score")
+    names(obj@meta.data)[names(obj@meta.data) == "mapping.score"] <- Stringendo::kpp(prefix, ref, "mapping.score")
   }
 
   print(tail(colnames(obj@meta.data), 10))
@@ -1670,7 +1670,7 @@ transferLabelsSeurat <- function(
     x = reference_ident
   ),
   predictions_col = "predicted.id",
-  predictions_score = sppp(new_ident, "score"),
+  predictions_score = Stringendo::sppp(new_ident, "score"),
   save_anchors = TRUE,
   reference_suffix = "REFERENCE.obj",
   plot_suffix = NULL,
@@ -1680,7 +1680,7 @@ transferLabelsSeurat <- function(
 ) {
   #
   if (is.null(reference_obj)) {
-    iprint("Loading reference object:", basename(reference_path))
+    Stringendo::iprint("Loading reference object:", basename(reference_path))
     stopifnot(file.exists(reference_path))
     reference_obj <- readr::read_rds(reference_path)
   } else {
@@ -1735,7 +1735,7 @@ transferLabelsSeurat <- function(
   )
 
   qSeuViolin(
-    feature = ppp(new_ident, "score"), ident = new_ident,
+    feature = Stringendo::ppp(new_ident, "score"), ident = new_ident,
     sub = Seurat.utils:::.parseBasicObjStats(query_obj),
     pt.size = 0.0, obj = query_obj
   )
@@ -1817,7 +1817,7 @@ matchBestIdentity <- function(
   suffix = gsub(prefix, "", x = reference_ident),
   # to_suffix = "matched",
   # to_suffix = FixPlotName(gsub(pattern = "[a-zA-Z_]", replacement = "", x = ident_to_rename)),
-  new_ident_name = kpp(prefix, ident_to_rename, "match.to", suffix),
+  new_ident_name = Stringendo::kpp(prefix, ident_to_rename, "match.to", suffix),
   plot_suffix = prefix,
   barplot_match = TRUE,
   barplot_fractions = TRUE,
@@ -1835,7 +1835,7 @@ matchBestIdentity <- function(
 
   obj@meta.data[, new_ident_name] <- translation[, 1]
 
-  imessage("new ident name:", new_ident_name)
+  Stringendo::imessage("new ident name:", new_ident_name)
   px <- clUMAP(ident = new_ident_name, obj = obj, suffix = plot_suffix, w = w, h = h, ...)
   print(px)
 
@@ -1904,10 +1904,10 @@ matchBestIdentity <- function(
   }
 
   cat_query <- unique(df[[query_col]])
-  imessage(length(cat_query), "categories to rename in", query_col, ":", head(cat_query), "...")
+  Stringendo::imessage(length(cat_query), "categories to rename in", query_col, ":", head(cat_query), "...")
 
   cat_ref <- unique(df[[ref_col]])
-  imessage(length(cat_ref), "reference categories in", ref_col, ":", head(cat_ref), "...")
+  Stringendo::imessage(length(cat_ref), "reference categories in", ref_col, ":", head(cat_ref), "...")
 
   # Create a table of the most frequent reference values for each query category
   replacement_table <- df |>
@@ -1930,14 +1930,14 @@ matchBestIdentity <- function(
   # Plot assignment quality
   if (show_plot) {
     px <- ggExpress::qbarplot(quality,
-      label = percentage_formatter(quality, digitz = 1),
+      label = Stringendo::percentage_formatter(quality, digitz = 1),
       ext = ext,
       suffix = suffix_barplot,
       plotname = "Assignment Quality",
-      filename = make.names(kpp("Assignment Quality", suffix_barplot, ext)),
+      filename = make.names(Stringendo::kpp("Assignment Quality", suffix_barplot, ext)),
       subtitle = paste(
         "From", colnames(df)[1], "->", colnames(df)[2], "| median",
-        percentage_formatter(median(quality)), "\n",
+        Stringendo::percentage_formatter(median(quality)), "\n",
         sum(quality > min.thr), "clusters above 50% match"
       ),
       hline = min.thr, filtercol = -1,

--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -108,11 +108,11 @@ processSeuratObject <- function(obj, param.list = p, species_ = "human",
     stopifnot("variables.2.regress is not found in @meta" = variables.2.regress %in% colnames(obj@meta.data))
   }
 
-  iprint("nfeatures:", nfeatures)
-  iprint("n.PC:", n.PC)
-  iprint("snn_res:", resolutions)
-  iprint("variables.2.regress (ScaleData):", variables.2.regress)
-  if (use_harmony) iprint("variables.2.regress (Harmony):", harmony.covariates)
+  Stringendo::iprint("nfeatures:", nfeatures)
+  Stringendo::iprint("n.PC:", n.PC)
+  Stringendo::iprint("snn_res:", resolutions)
+  Stringendo::iprint("variables.2.regress (ScaleData):", variables.2.regress)
+  if (use_harmony) Stringendo::iprint("variables.2.regress (Harmony):", harmony.covariates)
 
   # Save parameters _________________________________________________
   param.list$"n.var.genes" <- nfeatures
@@ -156,7 +156,7 @@ processSeuratObject <- function(obj, param.list = p, species_ = "human",
     obj <- calc.q99.Expression.and.set.all.genes(obj = obj, quantileX = .99)
 
     message("------------------- ScaleData -------------------")
-    tic(kpipe("ScaleData", kppc(variables.2.regress)))
+    tic(Stringendo::kpipe("ScaleData", Stringendo::kppc(variables.2.regress)))
     obj <- ScaleData(obj, assay = "RNA", verbose = TRUE, vars.to.regress = variables.2.regress, ...)
     toc()
 
@@ -173,18 +173,18 @@ processSeuratObject <- function(obj, param.list = p, species_ = "human",
       message("------------------- Split layers -------------------")
 
       m.REGR <- obj@meta.data[, harmony.covariates, drop = FALSE]
-      stopif("Harmony cannot regress numeric variables" = any(sapply(m.REGR, is.numeric)))
+      Stringendo::stopif("Harmony cannot regress numeric variables" = any(sapply(m.REGR, is.numeric)))
 
       obj$"regress_out" <- xr <- apply(m.REGR, 1, kppu)
-      nr_new_layers <- nr.unique(xr)
+      nr_new_layers <- CodeAndRoll2::nr.unique(xr)
       cells_per_layer <- table(xr)
 
-      warnif(
+      Stringendo::warnif(
         "Too few (<5) cells in some regress_out categories:" = any(cells_per_layer < 5),
         "Too many (>25) regress_out categories" = nr_new_layers > 25
       )
       message("Number of regress_out categories:", nr_new_layers)
-      message("Cells per regress_out category:", kppc(head(sort(cells_per_layer))), "...")
+      message("Cells per regress_out category:", Stringendo::kppc(head(sort(cells_per_layer))), "...")
       if (T) hist(cells_per_layer)
 
       tic("Split layers by regress_out")
@@ -240,13 +240,13 @@ processSeuratObject <- function(obj, param.list = p, species_ = "human",
 
   if (save) {
     message("------------------- Saving -------------------")
-    create_set_OutDir(WorkingDir)
+    MarkdownReports::create_set_OutDir(WorkingDir)
     xsave(obj, suffix = "reprocessed", paramList = param.list)
   }
 
   if (plot) {
     message("------------------- Plotting -------------------")
-    try.dev.off()
+    MarkdownHelpers::try.dev.off()
 
     try(suPlotVariableFeatures(obj = obj, assay = "RNA"), silent = TRUE)
 
@@ -343,7 +343,7 @@ runDGEA <- function(obj,
                     # ordering = "ordered", # param.list$"cl.annotation"
                     directory,
                     # dir_suffix,
-                    subdirectory = ppp("DGEA_res", idate()),
+                    subdirectory = Stringendo::ppp("DGEA_res", Stringendo::idate()),
                     add.combined.score = TRUE,
                     save.obj = TRUE,
                     calculate.DGEA = TRUE,
@@ -369,7 +369,7 @@ runDGEA <- function(obj,
     dir.exists(directory)
   )
 
-  create_set_OutDir(directory, subdirectory, newName = "dir_DGEA")
+  MarkdownReports::create_set_OutDir(directory, subdirectory, newName = "dir_DGEA")
   dir_DGEA <- OutDir
 
   # Log utilized parameters from param.list
@@ -396,18 +396,18 @@ runDGEA <- function(obj,
 
   # Retrieve analyzed DE resolutions
   message("Resolutions analyzed:")
-  df.markers.all <- Idents.for.DEG <- list.fromNames(x = res.analyzed.DE)
+  df.markers.all <- Idents.for.DEG <- CodeAndRoll2::list.fromNames(x = res.analyzed.DE)
 
 
   if (clean.misc.slot) {
     message("Clearing the misc slot: df.markers and top.markers.resX")
-    topMslots <- grepv("top.markers.res", names(obj@misc))
+    topMslots <- CodeAndRoll2::grepv("top.markers.res", names(obj@misc))
     obj@misc[topMslots] <- NULL
   }
 
   if (clean.meta.data) {
     message("Clearing the meta.data clustering columns.")
-    topMslots <- grepv("top.markers.res", names(obj@meta.data))
+    topMslots <- CodeAndRoll2::grepv("top.markers.res", names(obj@meta.data))
     cl.ordered <- GetOrderedClusteringRuns(obj = obj)
     obj@meta.data[, cl.ordered] <- NULL
     # cl.names <- GetNamedClusteringRuns(obj = obj, pat = "^cl.names.*[0-1]\\.[0-9]",
@@ -420,7 +420,7 @@ runDGEA <- function(obj,
     message("Renumbering ----------------------------------------")
     for (i in 1:length(res.analyzed.DE)) {
       res <- res.analyzed.DE[i]
-      create_set_OutDir(paste0(dir_DGEA, ppp("res", res)))
+      MarkdownReports::create_set_OutDir(paste0(dir_DGEA, Stringendo::ppp("res", res)))
       message(i)
 
       # Reorder clusters based on average expression of markers
@@ -457,11 +457,11 @@ runDGEA <- function(obj,
     message("Calculating ----------------------------------------")
     for (i in 1:length(res.analyzed.DE)) {
       res <- res.analyzed.DE[i]
-      tag.res <- ppp("res", res)
+      tag.res <- Stringendo::ppp("res", res)
       df.slot <- if (!is.null(ident)) ident else tag.res
 
       message("Resolution: ", res, " -----------")
-      create_set_OutDir(paste0(dir_DGEA, tag.res))
+      MarkdownReports::create_set_OutDir(paste0(dir_DGEA, tag.res))
 
       message("Ident.for.DEG: ", Idents.for.DEG[[i]])
       Idents(obj) <- Idents.for.DEG[[i]]
@@ -493,24 +493,24 @@ runDGEA <- function(obj,
       obj@misc$"df.markers"[[df.slot]] <- df.markers
 
       # Save results to disk
-      fname <- ppp("df.markers", res)
+      fname <- Stringendo::ppp("df.markers", res)
       ReadWriter::write.simple.tsv(df.markers, filename = fname, v = FALSE)
       df.markers.all[[i]] <- df.markers
       xsave(df.markers, suffix = df.slot, v = FALSE)
     } # end for loop
 
     # Save final results to disk
-    create_set_OutDir(directory, subdirectory)
+    MarkdownReports::create_set_OutDir(directory, subdirectory)
 
     # Assign df.markers.all to global environment
-    ReadWriter::write.simple.xlsx(named_list = df.markers.all, filename = kpp("df.markers.all", kppd(res.analyzed.DE), idate()))
+    ReadWriter::write.simple.xlsx(named_list = df.markers.all, filename = Stringendo::kpp("df.markers.all", Stringendo::kppd(res.analyzed.DE), Stringendo::idate()))
     assign("df.markers.all", df.markers.all, envir = .GlobalEnv)
 
 
     if (save.obj) {
-      create_set_OutDir(WorkingDir)
-      tag <- if (is.null(ident)) kpp("res", res.analyzed.DE) else ident
-      xsave(obj, suffix = kpp("w.DGEA", tag))
+      MarkdownReports::create_set_OutDir(WorkingDir)
+      tag <- if (is.null(ident)) Stringendo::kpp("res", res.analyzed.DE) else ident
+      xsave(obj, suffix = Stringendo::kpp("w.DGEA", tag))
     }
   } # end if calculate.DGEA
 
@@ -521,10 +521,10 @@ runDGEA <- function(obj,
     for (i in 1:length(res.analyzed.DE)) {
       res <- res.analyzed.DE[i]
       message("Resolution: ", res)
-      tag.res <- ppp("res", res)
+      tag.res <- Stringendo::ppp("res", res)
       df.slot <- if (!is.null(ident)) ident else tag.res
 
-      create_set_OutDir(paste0(dir_DGEA, df.slot))
+      MarkdownReports::create_set_OutDir(paste0(dir_DGEA, df.slot))
 
       df.markers <- obj@misc$"df.markers"[[df.slot]]
       Stringendo::stopif(is.null(df.markers))
@@ -549,7 +549,7 @@ runDGEA <- function(obj,
 
         if (numeric.clusters) {
           obj <- AutoLabelTop.logFC(group.by = Idents.for.DEG[[i]], df_markers = df.markers, obj = obj, plot.top.genes = FALSE)
-          clUMAP(ident = ppp("cl.names.top.gene", Idents.for.DEG[[i]]), obj = obj, caption = umap_caption)
+          clUMAP(ident = Stringendo::ppp("cl.names.top.gene", Idents.for.DEG[[i]]), obj = obj, caption = umap_caption)
         }
       } # end if auto.cluster.naming
 
@@ -573,7 +573,7 @@ runDGEA <- function(obj,
           geom_vline(xintercept = 1) +
           theme_linedraw()
 
-        qqSave(ggobj = p.deg.hist, w = 10, h = 6, title = ppp("Enrichment log2FC per cluster", res))
+        ggExpress::qqSave(ggobj = p.deg.hist, w = 10, h = 6, title = Stringendo::ppp("Enrichment log2FC per cluster", res))
       }
 
       # Plot per-cluster enriched gene counts ________________________________________
@@ -594,9 +594,9 @@ runDGEA <- function(obj,
         (NrOfHighlySignLFC2_genes <- lfc2_hiSig_genes |>
           summarise(n = n()) |>
           deframe() |>
-          sortbyitsnames())
+          CodeAndRoll2::sortbyitsnames())
 
-        qbarplot(NrOfHighlySignLFC2_genes,
+        ggExpress::qbarplot(NrOfHighlySignLFC2_genes,
           label = NrOfHighlySignLFC2_genes,
           plotname = "Number of diff. genes per cluster",
           subtitle = "Genes with avg_log2FC > 1 and p_val_adj < 0.05",
@@ -613,13 +613,13 @@ runDGEA <- function(obj,
             deframe()
 
           names(genes_list) <- unique(lfc2_hiSig_genes$"cluster")
-          genes_list <- sortbyitsnames(genes_list)
-          names(genes_list) <- ppp("cl", names(genes_list), top_genes, "DGs")
+          genes_list <- CodeAndRoll2::sortbyitsnames(genes_list)
+          names(genes_list) <- Stringendo::ppp("cl", names(genes_list), top_genes, "DGs")
 
           # write out the gene list, each element to a txt file.
-          create_set_OutDir(paste0(dir_DGEA, ppp("res", res), "/top_genes"))
+          MarkdownReports::create_set_OutDir(paste0(dir_DGEA, Stringendo::ppp("res", res), "/top_genes"))
           for (g in 1:length(genes_list)) {
-            write.simple.vec(input_vec = genes_list[[g]], filename = names(genes_list)[g], v = FALSE)
+            ReadWriter::write.simple.vec(input_vec = genes_list[[g]], filename = names(genes_list)[g], v = FALSE)
           } # for cluster
         }
       } # end if plot.log.top.gene.stats
@@ -628,7 +628,7 @@ runDGEA <- function(obj,
   # create_set_OutDir(directory, subdirectory)
 
   # Return obj and df.markers.all to global environment
-  create_set_Original_OutDir()
+  MarkdownReports::create_set_Original_OutDir()
   return(obj)
 } # end runDGEA
 
@@ -725,7 +725,7 @@ parallel.computing.by.future <- function(cores = 4, maxMemSize = 4000 * 1024^2) 
   user_input <- readline(prompt = "Are you sure that memory should not be cleaned before parallelizing? (y/n)")
 
   if (user_input == "y") {
-    iprint("N. cores", cores)
+    Stringendo::iprint("N. cores", cores)
     library(future)
     # plan("multiprocess", workers = cores)
     plan("multisession", workers = cores)
@@ -768,7 +768,7 @@ IntersectGeneLsWithObject <- function(genes, obj = combined.obj, n_genes_shown =
   all.genes.found <- all(genes %in% rownames(obj))
   if (!all.genes.found) {
     symbols.missing <- setdiff(genes, rownames(obj))
-    iprint(length(symbols.missing), "symbols.missing:", symbols.missing)
+    Stringendo::iprint(length(symbols.missing), "symbols.missing:", symbols.missing)
     message(" > Running HGNChelper::checkGeneSymbols() to update symbols")
 
     HGNC.updated <- HGNChelper::checkGeneSymbols(genes, unmapped.as.na = FALSE, map = NULL, species = species_)
@@ -836,14 +836,14 @@ SelectHighlyExpressedGenesq99 <- function(genes, obj = combined.obj,
   if (length(genes.expr) < length(genes)) message("Some genes not expressed. Recommend to IntersectGeneLsWithObject() first.")
 
   q99.expression <- obj@misc$expr.q99
-  print(pc_TRUE(q99.expression == 0, suffix = "of genes at q99.expression are zero"))
+  print(CodeAndRoll2::pc_TRUE(q99.expression == 0, suffix = "of genes at q99.expression are zero"))
   genes.expr.high <- q99.expression[genes.expr]
-  if (sort) genes.expr.high <- sort.decreasing(genes.expr.high)
+  if (sort) genes.expr.high <- CodeAndRoll2::sort.decreasing(genes.expr.high)
   print(genes.expr.high)
   genes.filt <- names(genes.expr.high)[genes.expr.high > above]
 
-  SFX <- kppws("of the genes are above min. q99 expression of:", above)
-  print(pc_TRUE(genes.expr %in% genes.filt, suffix = SFX))
+  SFX <- Stringendo::kppws("of the genes are above min. q99 expression of:", above)
+  print(CodeAndRoll2::pc_TRUE(genes.expr %in% genes.filt, suffix = SFX))
 
   return(genes.filt)
 }
@@ -869,19 +869,19 @@ AreTheseCellNamesTheSame <- function(
   min.overlap = 0.33
 ) {
   Cellname.Overlap <- list(vec1, vec2)
-  names(Cellname.Overlap) <- if (!isFALSE(names)) names else c(substitute_deparse(vec1), substitute_deparse(vec2))
+  names(Cellname.Overlap) <- if (!isFALSE(names)) names else c(Stringendo::substitute_deparse(vec1), Stringendo::substitute_deparse(vec2))
 
   cells.in.both <- intersect(vec1, vec2)
-  sbb <- percentage_formatter(length(cells.in.both) / length(vec2), suffix = "of cells (GEX) in have a UVI assigned")
+  sbb <- Stringendo::percentage_formatter(length(cells.in.both) / length(vec2), suffix = "of cells (GEX) in have a UVI assigned")
   ggExpress::qvenn(Cellname.Overlap, subt = sbb)
-  iprint("Venn diagram saved.")
-  iprint(sbb)
+  Stringendo::iprint("Venn diagram saved.")
+  Stringendo::iprint(sbb)
 
   Nr.overlapping <- length(intersect(vec1, vec2))
   Nr.total <- length(union(vec1, vec2))
   Percent_Overlapping <- Nr.overlapping / Nr.total
   print("")
-  report <- percentage_formatter(Percent_Overlapping,
+  report <- Stringendo::percentage_formatter(Percent_Overlapping,
     prefix = "In total,",
     suffix = paste("of the cellIDs overlap across", names(Cellname.Overlap)[1], "and", names(Cellname.Overlap)[2])
   )
@@ -909,9 +909,9 @@ AreTheseCellNamesTheSame <- function(
 #' @export
 addToMiscOrToolsSlot <- function(obj, pocket_name = "misc",
                                  slot_value = NULL,
-                                 slot_name = substitute_deparse(slot_value),
+                                 slot_name = Stringendo::substitute_deparse(slot_value),
                                  sub_slot_value = NULL,
-                                 sub_slot_name = substitute_deparse(sub_slot_value),
+                                 sub_slot_name = Stringendo::substitute_deparse(sub_slot_value),
                                  overwrite = FALSE) {
   message("Running addToMiscOrToolsSlot()...")
 
@@ -1008,8 +1008,8 @@ showMiscSlots <- function(obj = combined.obj, max.level = 1, subslot = NULL,
   str(slotX, max.level = max.level, ...)
 
   # Path to slot
-  msg <- paste0(substitute_deparse(obj), "@misc")
-  if (!is.null(subslot)) msg <- paste0(msg, "$", substitute_deparse(subslot))
+  msg <- paste0(Stringendo::substitute_deparse(obj), "@misc")
+  if (!is.null(subslot)) msg <- paste0(msg, "$", Stringendo::substitute_deparse(subslot))
   message(msg)
 }
 
@@ -1064,7 +1064,7 @@ calc.q99.Expression.and.set.all.genes <- function(
   ...
 ) {
   top.quant <- (1 - quantileX)
-  message("\nCalculating the gene expression level at the the top ", percentage_formatter(top.quant), " of cells. | q: ", quantileX)
+  message("\nCalculating the gene expression level at the the top ", Stringendo::percentage_formatter(top.quant), " of cells. | q: ", quantileX)
   message("slot: ", slot, " assay: ", assay, ".\n")
 
   nr.total.cells <- ncol(obj)
@@ -1081,12 +1081,12 @@ calc.q99.Expression.and.set.all.genes <- function(
     is.character(suffix)
   )
 
-  warnifnot(
+  Stringendo::warnifnot(
     slot %in% c("data", "scale.data", "counts"),
     assay %in% c("RNA", "integrated")
   )
 
-  warnif(
+  Stringendo::warnif(
     ">1000 cells in the top the quantileX (with >0 expression). Increase quantileX not to miss genes expressed in small populations!" = n.cells.in.top.quantile > 1000,
     "<50 cells in the top the quantileX (with >0 expression). Decrease quantileX for robustness!" = n.cells.in.top.quantile < 50
   )
@@ -1133,18 +1133,18 @@ calc.q99.Expression.and.set.all.genes <- function(
 
   # Prepare for plotting ____________________________________________________________
   qname <- paste0("q", quantileX * 100)
-  slot_name <- kpp("expr", qname)
+  slot_name <- Stringendo::kpp("expr", qname)
 
   print("Calculating Gene Quantiles")
   expr.q99.raw <- sparseMatrixStats::rowQuantiles(data_mtx, probs = quantileX)
-  expr.q99 <- iround(expr.q99.raw)
+  expr.q99 <- CodeAndRoll2::iround(expr.q99.raw)
 
   log2.gene.expr.of.the.Xth.quantile <- as.numeric(log2(expr.q99 + 1)) # strip names
   qnameP <- paste0(100 * quantileX, "th quantile")
 
   # Plot the distribution of gene expression in the 99th quantile _________________________________
   if (plot) {
-    SBT <- kollapse(pc_TRUE(expr.q99 > 0, NumberAndPC = TRUE), " genes have ", qname, " expr. > 0 (in ", n.cells.in.top.quantile, " cells).")
+    SBT <- Stringendo::kollapse(CodeAndRoll2::pc_TRUE(expr.q99 > 0, NumberAndPC = TRUE), " genes have ", qname, " expr. > 0 (in ", n.cells.in.top.quantile, " cells).")
     CPT <- paste(n.cells.in.top.quantile, "cells in", qnameP, "from", ncol(data_mtx), "cells in", dtag, "object.")
 
     pobj <- ggExpress::qhistogram(log2.gene.expr.of.the.Xth.quantile,
@@ -1181,7 +1181,7 @@ calc.q99.Expression.and.set.all.genes <- function(
   # if (set.all.genes) obj@misc$'all.genes' = all.genes
   if (set.misc) obj@misc[[slot_name]] <- expr.q99
 
-  iprint(
+  Stringendo::iprint(
     "Quantile", quantileX, "is now stored under obj@misc$", slot_name,
     "Please execute:\n",
     "`Seurat.utils::recall.all.genes(obj)` or `obj@misc$all.genes`\n\n"
@@ -1235,7 +1235,7 @@ filterCodingGenes <- function(
   # Filter the genes
   combined_pattern <- paste(pattern_NC, collapse = "|")
   genes_discarded <- genes[stringr::str_detect(genes, combined_pattern)]
-  if (v) iprint("Examples of", length(genes_discarded), "discarded symbols:", CodeAndRoll2::trail(genes_discarded, 5))
+  if (v) Stringendo::iprint("Examples of", length(genes_discarded), "discarded symbols:", CodeAndRoll2::trail(genes_discarded, 5))
 
   genes_kept <- genes[stringr::str_detect(genes, combined_pattern, negate = TRUE)]
 
@@ -1295,7 +1295,7 @@ filterExpressedGenes <- function(
     is.character(genes),
     is.numeric(threshold), length(threshold) == 1
   )
-  stopif(is.null(gene_list))
+  Stringendo::stopif(is.null(gene_list))
 
 
   # Step 1: Intersect the gene symbols with the names in the list and report statistics
@@ -1311,7 +1311,7 @@ filterExpressedGenes <- function(
   filtered_genes <- matching_genes[sapply(matching_genes, function(g) gene_list[[g]] >= threshold)]
   message("Number of genes above the threshold: ", length(filtered_genes), " from ", length(matching_genes))
 
-  print(as.numeric.wNames.character(gene_list[genes]))
+  print(CodeAndRoll2::as.numeric.wNames.character(gene_list[genes]))
 
   # Step 3: Conditionally sort genes according to their expression in descending order
   if (sort_by_expr) {
@@ -1353,7 +1353,7 @@ RenameClustering <- function(
   namedVector = ManualNames,
   orig.ident = "RNA_snn_res.0.3",
   suffix.new.ident = "ManualNames",
-  new.ident = ppp(orig.ident, suffix.new.ident),
+  new.ident = Stringendo::ppp(orig.ident, suffix.new.ident),
   obj = combined.obj,
   suffix.plot = "",
   plot_umaps = TRUE,
@@ -1367,7 +1367,7 @@ RenameClustering <- function(
 
   obj <- AddMetaData(object = obj, metadata = NewX, col.name = new.ident)
 
-  iprint("new.ident is", new.ident, "created from", orig.ident)
+  Stringendo::iprint("new.ident is", new.ident, "created from", orig.ident)
   print("")
 
   if (plot_umaps) {
@@ -1377,7 +1377,7 @@ RenameClustering <- function(
     print(clUMAP(new.ident, suffix = suffix.plot, sub = suffix.plot, obj = obj, ...))
     clUMAP(new.ident, suffix = suffix.plot, sub = suffix.plot, label = FALSE, obj = obj, ...)
   } else {
-    iprint("New ident:", new.ident)
+    Stringendo::iprint("New ident:", new.ident)
   }
 
   return(obj)
@@ -1435,7 +1435,7 @@ shorten_clustering_names <- function(str) {
 #' @return Prints and returns the sorted unique cluster names as a character vector.
 #' @export
 getClusterNames <- function(obj = combined.obj, ident = GetClusteringRuns(obj)[2]) {
-  iprint("ident used:", ident)
+  Stringendo::iprint("ident used:", ident)
   clz <- as.character(sort(deframe(unique(obj[[ident]]))))
   cat(dput(clz))
 }
@@ -1571,7 +1571,7 @@ GetNumberOfClusters <- function(obj = combined.obj) { # Get Number Of Clusters
   print("## Number of clusters: ---------")
   for (cc in clustering.results) {
     NrCl <- length(unique(obj@meta.data[[cc]]))
-    iprint(cc, "   ", NrCl)
+    Stringendo::iprint(cc, "   ", NrCl)
   }
 }
 
@@ -1633,14 +1633,14 @@ calc.cluster.averages <- function(
     paste("Threshold at", absolute.thr)
   } else {
     paste(
-      "Black lines: ", kppd(Stringendo::percentage_formatter(c(1 - quantile.thr, quantile.thr))), "quantiles |",
+      "Black lines: ", Stringendo::kppd(Stringendo::percentage_formatter(c(1 - quantile.thr, quantile.thr))), "quantiles |",
       "Cl. >", Stringendo::percentage_formatter(quantile.thr), "are highlighted. |", split_by
     )
   },
-  fname = ppp(col_name, split_by, "cluster.average.barplot.pdf", ...)
+  fname = Stringendo::ppp(col_name, split_by, "cluster.average.barplot.pdf", ...)
 ) { # calc.cluster.averages of a m
-  iprint(substitute_deparse(obj), "split by", split_by)
-  if (absolute.thr) iprint("In case of the absolute threshold, only the returned values are correct, the plot annotations are not!")
+  Stringendo::iprint(Stringendo::substitute_deparse(obj), "split by", split_by)
+  if (absolute.thr) Stringendo::iprint("In case of the absolute threshold, only the returned values are correct, the plot annotations are not!")
 
   if (plot.UMAP.too) qUMAP(obj = obj, feature = col_name)
 
@@ -1651,27 +1651,27 @@ calc.cluster.averages <- function(
     summarize(
       "nr.cells" = n(),
       "mean" = mean(!!sym(col_name), na.rm = TRUE),
-      "SEM" = sem(!!sym(col_name), na.rm = TRUE),
+      "SEM" = CodeAndRoll2::sem(!!sym(col_name), na.rm = TRUE),
       "median" = median(!!sym(col_name), na.rm = TRUE),
-      "SE.median" = 1.2533 * sem(!!sym(col_name), na.rm = TRUE)
+      "SE.median" = 1.2533 * CodeAndRoll2::sem(!!sym(col_name), na.rm = TRUE)
     )
 
   if (simplify) {
     av.score <- df.summary[[stat]]
-    names(av.score) <- if (!isFALSE(prefix.cl.names)) ppp("cl", df.summary[[1]]) else df.summary[[1]]
-    av.score <- sortbyitsnames(av.score)
+    names(av.score) <- if (!isFALSE(prefix.cl.names)) Stringendo::ppp("cl", df.summary[[1]]) else df.summary[[1]]
+    av.score <- CodeAndRoll2::sortbyitsnames(av.score)
     if (scale.zscore) av.score <- (scale(av.score)[, 1])
 
     cutoff <- if (absolute.thr) absolute.thr else quantile(av.score, quantile.thr)
     cutoff.low <- if (absolute.thr) NULL else quantile(av.score, (1 - quantile.thr))
 
-    iprint("quantile.thr:", quantile.thr)
+    Stringendo::iprint("quantile.thr:", quantile.thr)
     if (plotit) {
       if (histogram) {
         p <- ggExpress::qhistogram(
           vec = as.numeric(av.score), save = FALSE,
           vline = cutoff,
-          plotname = ppp(title, quantile.thr),
+          plotname = Stringendo::ppp(title, quantile.thr),
           bins = nbins,
           subtitle = paste(subtitle, "| median in blue/dashed"),
           ylab = ylab.text,
@@ -1682,7 +1682,7 @@ calc.cluster.averages <- function(
           geom_vline(xintercept = cutoff.low, lty = 2)
 
         print(p)
-        title_ <- ppp(title, suffix, flag.nameiftrue(scale.zscore))
+        title_ <- Stringendo::ppp(title, suffix, Stringendo::flag.nameiftrue(scale.zscore))
         ggExpress::qqSave(ggobj = p, title = title_, w = width, h = height)
       } else {
         p <- ggExpress::qbarplot(
@@ -1699,16 +1699,16 @@ calc.cluster.averages <- function(
           geom_hline(yintercept = cutoff.low, lty = 2)
 
         print(p)
-        title_ <- ppp(title, suffix, flag.nameiftrue(scale.zscore))
-        qqSave(ggobj = p, title = title_, fname = ppp(title_, split_by, "png"), w = width, h = height)
+        title_ <- Stringendo::ppp(title, suffix, Stringendo::flag.nameiftrue(scale.zscore))
+        ggExpress::qqSave(ggobj = p, title = title_, fname = Stringendo::ppp(title_, split_by, "png"), w = width, h = height)
       }
     }
 
-    if (report) print(paste0(col_name, ": ", paste(iround(av.score), collapse = " vs. ")))
+    if (report) print(paste0(col_name, ": ", paste(CodeAndRoll2::iround(av.score), collapse = " vs. ")))
     if (filter == "below") {
-      return(filter_LP(av.score, threshold = cutoff, plot.hist = FALSE))
+      return(MarkdownHelpers::filter_LP(av.score, threshold = cutoff, plot.hist = FALSE))
     } else if (filter == "above") {
-      return(filter_HP(av.score, threshold = cutoff, plot.hist = FALSE))
+      return(MarkdownHelpers::filter_HP(av.score, threshold = cutoff, plot.hist = FALSE))
     } else {
       return(av.score)
     }
@@ -1744,9 +1744,9 @@ plot.expression.rank.q90 <- function(obj = combined.obj, gene = "ACTB", filterZe
   gene.found <- gene %in% names(expr.all)
   stopifnot(gene.found)
 
-  if (expr.GOI == 0) iprint(gene, "is not expressed. q90-av.exp:", expr.GOI) else if (expr.GOI < 0.05) iprint(gene, "is lowly expressed. q90-av.exp:", expr.GOI)
+  if (expr.GOI == 0) Stringendo::iprint(gene, "is not expressed. q90-av.exp:", expr.GOI) else if (expr.GOI < 0.05) Stringendo::iprint(gene, "is lowly expressed. q90-av.exp:", expr.GOI)
   if (filterZero) {
-    iprint("Zero 'q90 expression' genes (", pc_TRUE(expr.all == 0), ") are removed.")
+    Stringendo::iprint("Zero 'q90 expression' genes (", CodeAndRoll2::pc_TRUE(expr.all == 0), ") are removed.")
     expr.all <- expr.all[expr.all > 0]
   }
   counts <- sum(obj@assays$RNA@counts[gene, ])
@@ -1810,7 +1810,7 @@ set.mm <- function(obj = combined.obj) {
 #' @export
 ww.get.1st.Seur.element <- function(obj) {
   if (is(obj)[1] == "list") {
-    iprint("A list of objects is provided, taking the 1st from", length(obj), "elements.")
+    Stringendo::iprint("A list of objects is provided, taking the 1st from", length(obj), "elements.")
     obj <- obj[[1]]
   }
   stopifnot(is(obj) == "Seurat")
@@ -1849,7 +1849,7 @@ recall.all.genes <- function(obj = combined.obj, overwrite = FALSE) {
     }
   } else {
     message("  ->   Slot 'all.genes' does not exist in obj@misc.")
-    hits <- grepv(pattern = "expr.", names(obj@misc))
+    hits <- CodeAndRoll2::grepv(pattern = "expr.", names(obj@misc))
     if (!is.null(hits)) {
       message("Found instead (", hits, "). Returning 1st element: ", hits[1])
       all.genes <- obj@misc[[hits[1]]]
@@ -1896,7 +1896,7 @@ recall.meta.tags.n.datasets <- function(obj = combined.obj) {
       print(head(unlist(meta.tags)))
       MarkdownHelpers::ww.assign_to_global(name = "meta.tags", value = meta.tags)
     } else {
-      iprint("  ->   Variable 'meta.tags' already exists in the global namespace.")
+      Stringendo::iprint("  ->   Variable 'meta.tags' already exists in the global namespace.")
     }
   } else {
     print("  ->   Slot 'meta.tags' does not exist in obj@misc.")
@@ -2025,7 +2025,7 @@ save.parameters <- function(obj = combined.obj, params = p, overwrite = TRUE) {
 #'
 #' @examples
 #' sc_meta <- create_scCombinedMeta(experiment = "Experiment1")
-create_scCombinedMeta <- function(experiment, project_ = getProject()) {
+create_scCombinedMeta <- function(experiment, project_ = CodeAndRoll2::getProject()) {
   x <- list(
     experiment.corresponding = experiment,
     initialized = format(Sys.time(), format = "%Y.%m.%d | %H:%M:%S"),
@@ -2099,7 +2099,7 @@ copyMiscElements <- function(obj.from, obj.to, elements.needed, overwrite = TRUE
   for (element in existingElementsFrom) {
     obj.to@misc[[element]] <- obj.from@misc[[element]]
   }
-  iprint("@misc contains: ", names(obj.to@misc))
+  Stringendo::iprint("@misc contains: ", names(obj.to@misc))
 
   return(obj.to)
 }
@@ -2187,17 +2187,17 @@ subsetSeuObjByIdent <- function(
     identGroupKeep
   }
   message(
-    "ident: ", ident, " | ", length(identGroupKeep), " ID-groups selected: ", kppc(head(identGroupKeep)),
+    "ident: ", ident, " | ", length(identGroupKeep), " ID-groups selected: ", Stringendo::kppc(head(identGroupKeep)),
     "... | invert: ", invert, "\n"
   )
 
   idx.cells.pass <- obj@meta.data[[ident]] %in% identGroupKeep
   cellz <- colnames(obj)[idx.cells.pass]
 
-  PCT <- percentage_formatter(length(cellz) / ncol(obj))
+  PCT <- Stringendo::percentage_formatter(length(cellz) / ncol(obj))
   message(
     PCT, " or ", length(cellz), " cells are selected from ", ncol(obj),
-    ", using values (max 20): ", kppc(head(identGroupKeep, 20)), ", from ", ident, "."
+    ", using values (max 20): ", Stringendo::kppc(head(identGroupKeep, 20)), ", from ", ident, "."
   )
 
   x <- subset(x = obj, cells = cellz)
@@ -2223,7 +2223,7 @@ downsampleSeuObj <- function(obj = ls.Seurat[[i]], fractionCells = 0.25, nCells 
   set.seed(seed)
   if (isFALSE(nCells)) {
     cellIDs.keep <- sampleNpc(metaDF = obj@meta.data, pc = fractionCells)
-    iprint(
+    Stringendo::iprint(
       length(cellIDs.keep), "or", Stringendo::percentage_formatter(fractionCells),
       "of the cells are kept. Seed:", seed
     )
@@ -2232,7 +2232,7 @@ downsampleSeuObj <- function(obj = ls.Seurat[[i]], fractionCells = 0.25, nCells 
     # print(nKeep)
     cellIDs.keep <- sample(colnames(obj), size = nKeep, replace = FALSE)
     if (nKeep < nCells) {
-      iprint(
+      Stringendo::iprint(
         "Only", nCells,
         "cells were found in the object, so downsampling is not possible."
       )
@@ -2264,8 +2264,8 @@ downsampleSeuObj.and.Save <- function(
   # Seurat.utils:::.saveRDS.compress.in.BG(obj = obj_Xpc, fname = ppp(paste0(dir, substitute_deparse(obj),
   # suffix, nr.cells.kept, 'cells.with.min.features', min.features,"Rds" ) )
   xsave(obj_Xpc,
-    suffix = ppp(suffix, nr.cells.kept, "cells.with.min.features", min.features),
-    nthreads = nthreads, project = getProject(), showMemObject = TRUE, saveParams = FALSE
+    suffix = Stringendo::ppp(suffix, nr.cells.kept, "cells.with.min.features", min.features),
+    nthreads = nthreads, project = CodeAndRoll2::getProject(), showMemObject = TRUE, saveParams = FALSE
   )
 }
 
@@ -2352,11 +2352,11 @@ downsampleSeuObjByIdentAndMaxcells <- function(obj,
   Idents(obj) <- ident
   obj_ds <- subset(x = obj, cells = sampledCells)
 
-  fr_remaining <- iround(target_cells / orig_cells)
+  fr_remaining <- CodeAndRoll2::iround(target_cells / orig_cells)
   subb <- paste0("From ", ncol(obj), " reduced to ", ncol(obj_ds), " cells.")
 
   message(subb)
-  message("Total retained fraction: ", iround(ncol(obj_ds) / ncol(obj)))
+  message("Total retained fraction: ", CodeAndRoll2::iround(ncol(obj_ds) / ncol(obj)))
 
   if (verbose) {
     sample_stats <- data.frame(
@@ -2371,7 +2371,7 @@ downsampleSeuObjByIdentAndMaxcells <- function(obj,
   }
 
   if (plot_stats) {
-    qbarplot(vec = fr_remaining, subtitle = subb, label = fr_remaining, ylab = "fr. of cells", save = FALSE, plot = TRUE)
+    ggExpress::qbarplot(vec = fr_remaining, subtitle = subb, label = fr_remaining, ylab = "fr. of cells", save = FALSE, plot = TRUE)
   }
 
   return(obj_ds)
@@ -2509,7 +2509,7 @@ downsampleSeuObjByIdentAndMaxcells <- function(obj,
 #' )
 #'
 RelabelSmallCategories <- function(
-  obj, col_in, backup_col_name = ppp(col_in, "orig"),
+  obj, col_in, backup_col_name = Stringendo::ppp(col_in, "orig"),
   min_count = 100, small_label = "Other", v = TRUE
 ) {
   # Input assertions
@@ -2607,10 +2607,10 @@ removeResidualSmallClusters <- function(
     print(colX)
     tbl <- table(META[[colX]])
 
-    small.clusters[[i]] <- which_names(tbl <= max.cells)
+    small.clusters[[i]] <- CodeAndRoll2::which_names(tbl <= max.cells)
     cells.to.remove[[i]] <- all.cells[which(META[[colX]] %in% small.clusters[[i]])]
     if (length(cells.to.remove[[i]])) {
-      iprint(
+      Stringendo::iprint(
         length(cells.to.remove[[i]]), "cells in small clusters:", small.clusters[[i]],
         "| Cell counts:", tbl[small.clusters[[i]]]
       )
@@ -2629,12 +2629,12 @@ removeResidualSmallClusters <- function(
 
 
     if (length(all.cells.2.remove)) {
-      iprint(
+      Stringendo::iprint(
         ">>> a total of", length(all.cells.2.remove),
         "cells are removed which belonged to a small cluster in any of the identities."
       )
     } else {
-      iprint(">>> No cells are removed because belonging to small cluster.")
+      Stringendo::iprint(">>> No cells are removed because belonging to small cluster.")
     }
 
     cells.2.keep <- setdiff(all.cells, all.cells.2.remove)
@@ -2678,7 +2678,7 @@ dropLevelsSeurat <- function(obj = combined.obj, verbose = TRUE, also.character 
   if (verbose) {
     message(
       "Dropping levels in ", length(drop_in_these), " identities:\n",
-      kppc(drop_in_these)
+      Stringendo::kppc(drop_in_these)
     )
   }
 
@@ -2767,7 +2767,7 @@ removeCellsByUmap <- function(
     p <- p + geom_hline(yintercept = cutoff)
   }
   print(p)
-  qqSave(p, fname = kpp("UMAP.with.cutoff", umap_dim, sfx, cutoff, "png"), h = 7, w = 7)
+  ggExpress::qqSave(p, fname = Stringendo::kpp("UMAP.with.cutoff", umap_dim, sfx, cutoff, "png"), h = 7, w = 7)
 
   if (!only_plot_cutoff) {
     # Retrieve cell embeddings
@@ -2777,13 +2777,13 @@ removeCellsByUmap <- function(
     embedding_dim_x <- cell_embedding[, umap_dim]
 
     # Determine cells to remove based on cutoff
-    cells_to_remove <- if (cut_below) which_names(embedding_dim_x < cutoff) else which_names(embedding_dim_x >= cutoff)
+    cells_to_remove <- if (cut_below) CodeAndRoll2::which_names(embedding_dim_x < cutoff) else CodeAndRoll2::which_names(embedding_dim_x >= cutoff)
 
     # Report on cells removed
     if (length(cells_to_remove)) {
-      iprint(">>> A total of", length(cells_to_remove), "cells are removed which fell on UMAP aside cutoff:", cutoff)
+      Stringendo::iprint(">>> A total of", length(cells_to_remove), "cells are removed which fell on UMAP aside cutoff:", cutoff)
     } else {
-      iprint(">>> No cells are removed because of the UMAP dimension cutoff.")
+      Stringendo::iprint(">>> No cells are removed because of the UMAP dimension cutoff.")
     }
 
     # Subset object to include only cells not removed
@@ -2836,19 +2836,19 @@ downsampleListSeuObjsNCells <- function(
 
   names.ls <- names(ls.obj)
   n.datasets <- length(ls.obj)
-  iprint(NrCells, "cells")
+  Stringendo::iprint(NrCells, "cells")
 
   tictoc::tic("downsampleListSeuObjsNCells")
   if (foreach::getDoParRegistered()) {
     ls.obj.downsampled <- foreach::foreach(i = 1:n.datasets) %dopar% {
-      iprint(names(ls.obj)[i], Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
+      Stringendo::iprint(names(ls.obj)[i], Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
       downsampleSeuObj(obj = ls.obj[[i]], nCells = NrCells)
     }
     names(ls.obj.downsampled) <- names.ls
   } else {
-    ls.obj.downsampled <- list.fromNames(names.ls)
+    ls.obj.downsampled <- CodeAndRoll2::list.fromNames(names.ls)
     for (i in 1:n.datasets) {
-      iprint(names(ls.obj)[i], Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
+      Stringendo::iprint(names(ls.obj)[i], Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
       ls.obj.downsampled[[i]] <- downsampleSeuObj(obj = ls.obj[[i]], nCells = NrCells)
     }
   } # else
@@ -2858,7 +2858,7 @@ downsampleListSeuObjsNCells <- function(
   print(head(sapply(ls.obj.downsampled, ncol)))
 
   if (save_object) {
-    isave.RDS(obj = ls.obj.downsampled, suffix = ppp(NrCells, "cells"), inOutDir = TRUE)
+    isave.RDS(obj = ls.obj.downsampled, suffix = Stringendo::ppp(NrCells, "cells"), inOutDir = TRUE)
   } else {
     return(ls.obj.downsampled)
   }
@@ -2900,7 +2900,7 @@ downsampleListSeuObjsPercent <- function(
 
   names.ls <- names(ls.obj)
   n.datasets <- length(ls.obj)
-  iprint(fraction, "fraction")
+  Stringendo::iprint(fraction, "fraction")
 
   tictoc::tic("downsampleListSeuObjsPercent")
   if (foreach::getDoParRegistered()) {
@@ -2909,10 +2909,10 @@ downsampleListSeuObjsPercent <- function(
     }
     names(ls.obj.downsampled) <- names.ls
   } else {
-    ls.obj.downsampled <- list.fromNames(names.ls)
+    ls.obj.downsampled <- CodeAndRoll2::list.fromNames(names.ls)
     for (i in 1:n.datasets) {
       cells <- round(ncol(ls.obj[[1]]) * fraction)
-      iprint(names(ls.obj)[i], cells, "cells=", Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
+      Stringendo::iprint(names(ls.obj)[i], cells, "cells=", Stringendo::percentage_formatter(i / n.datasets, digitz = 2))
       ls.obj.downsampled[[i]] <- downsampleSeuObj(obj = ls.obj[[i]], fractionCells = fraction, seed = seed)
     }
   }
@@ -2923,7 +2923,7 @@ downsampleListSeuObjsPercent <- function(
   print(head(sapply(ls.obj, ncol)))
   print(head(sapply(ls.obj.downsampled, ncol)))
   if (save_object) {
-    isave.RDS(obj = ls.obj.downsampled, suffix = ppp(NrCells, "cells"), inOutDir = TRUE)
+    isave.RDS(obj = ls.obj.downsampled, suffix = Stringendo::ppp(NrCells, "cells"), inOutDir = TRUE)
   } else {
     return(ls.obj.downsampled)
   }
@@ -2973,7 +2973,7 @@ addCombinedScore2DGEAResults <- function(
   df = df.markers, p_val_min = 1e-25, pval_scaling = 0.001, colP = "p_val_adj",
   colLFC = CodeAndRoll2::grepv(pattern = c("avg_logFC|avg_log2FC"), x = colnames(df), perl = TRUE)
 ) {
-  p_clipped <- clip.at.fixed.value(x = df[[colP]], thr = p_val_min, above = FALSE)
+  p_clipped <- CodeAndRoll2::clip.at.fixed.value(x = df[[colP]], thr = p_val_min, above = FALSE)
   df$"combined.score" <- round(df[[colLFC]] * -log10(p_clipped / pval_scaling))
   return(df)
 }
@@ -3094,10 +3094,10 @@ StoreTop25Markers <- function(
     group_by(cluster) |>
     top_n(n = 25, wt = avg_2logFC) |>
     dplyr::select(gene) |>
-    col2named.vec.tbl() |>
-    splitbyitsnames()
+    CodeAndRoll2::col2named.vec.tbl() |>
+    CodeAndRoll2::splitbyitsnames()
 
-  obj@misc$"top25.markers"[[ppp("res", res)]] <- top25.markers
+  obj@misc$"top25.markers"[[Stringendo::ppp("res", res)]] <- top25.markers
   return(obj)
 }
 
@@ -3128,8 +3128,8 @@ StoreAllMarkers <- function(
   df_markers = df.markers, res = 0.5, digit = c(0, 3)[2]
 ) {
   if (digit) df_markers[, 1:5] <- signif(df_markers[, 1:5], digits = digit)
-  obj@misc$"df.markers"[[ppp("res", res)]] <- df_markers
-  iprint("DF markers are stored under:", "obj@misc$df.markers$", ppp("res", res))
+  obj@misc$"df.markers"[[Stringendo::ppp("res", res)]] <- df_markers
+  Stringendo::iprint("DF markers are stored under:", "obj@misc$df.markers$", Stringendo::ppp("res", res))
   return(obj)
 }
 
@@ -3283,10 +3283,10 @@ AutoLabelTop.logFC <- function(
   # Enrichment plot ______________________________________________________________
   if (plotEnrichment) {
     top_log2FC <- df.top.markers$"avg_log2FC"
-    names(top_log2FC) <- ppp(df.top.markers$"cluster", df.top.markers$"gene")
+    names(top_log2FC) <- Stringendo::ppp(df.top.markers$"cluster", df.top.markers$"gene")
     ggExpress::qbarplot(top_log2FC,
       plotname = "The strongest fold change by cluster",
-      label = iround(top_log2FC),
+      label = CodeAndRoll2::iround(top_log2FC),
       subtitle = group.by,
       ylab = "avg_log2FC", xlab = "clusters",
       hline = 2,
@@ -3294,9 +3294,9 @@ AutoLabelTop.logFC <- function(
     )
   }
 
-  top.markers <- col2named.vec.tbl(df.top.markers[, 1:2])
+  top.markers <- CodeAndRoll2::col2named.vec.tbl(df.top.markers[, 1:2])
 
-  obj@misc[[ppp("top.markers.res", res)]] <- top.markers
+  obj@misc[[Stringendo::ppp("top.markers.res", res)]] <- top.markers
 
   ids_CBC <- deframe(obj[[group.by]])
   ids <- unique(ids_CBC)
@@ -3306,17 +3306,17 @@ AutoLabelTop.logFC <- function(
     warning("Not all clusters returned DE-genes!", immediate. = TRUE)
     missing <- setdiff(ids, names(top.markers))
     names(missing) <- missing
-    iprint("missing:", missing)
-    top.markers <- sortbyitsnames(c(top.markers, missing))
+    Stringendo::iprint("missing:", missing)
+    top.markers <- CodeAndRoll2::sortbyitsnames(c(top.markers, missing))
   }
 
-  top.markers.ID <- ppp(names(top.markers), top.markers)
+  top.markers.ID <- Stringendo::ppp(names(top.markers), top.markers)
   names(top.markers.ID) <- names(top.markers)
   named.group.by <- top.markers.ID[ids_CBC]
 
   # Check if the clustering was ordered _____________________________________________________
   sfx.ord <- ifelse(grepl("ordered", group.by), group.by, "")
-  namedIDslot <- sppp("cl.names.top.gene.", sfx.ord)
+  namedIDslot <- Stringendo::sppp("cl.names.top.gene.", sfx.ord)
 
   obj <- addMetaDataSafe(obj = obj, metadata = as.character(named.group.by), col.name = namedIDslot, overwrite = TRUE)
   if (plot.top.genes) multiFeaturePlot.A4(list.of.genes = top.markers, suffix = suffix, obj = obj)
@@ -3407,7 +3407,7 @@ AutoLabel.KnownMarkers <- function(
   "Error Here"
 
   top.markers.df <- GetTopMarkersDF(dfDE = df_markers, order.by = lfcCOL, n = 1)
-  top.markers <- top.markers.df |> col2named.vec.tbl()
+  top.markers <- top.markers.df |> CodeAndRoll2::col2named.vec.tbl()
 
   missing.annotations <-
     top.markers.df |>
@@ -3418,11 +3418,11 @@ AutoLabel.KnownMarkers <- function(
     arrange(cluster) |>
     CodeAndRoll2::col2named.vec.tbl()
 
-  (top.markers.ID <- ppp(names(named.annotations), named.annotations))
+  (top.markers.ID <- Stringendo::ppp(names(named.annotations), named.annotations))
   names(top.markers.ID) <- names(top.markers)
   named.ident <- top.markers.ID[Idents(object = obj)]
 
-  namedIDslot <- ppp("cl.names.KnownMarkers", res)
+  namedIDslot <- Stringendo::ppp("cl.names.KnownMarkers", res)
   obj[[namedIDslot]] <- named.ident
   return(obj)
 }
@@ -3510,25 +3510,25 @@ Calc.Cor.Seurat <- function(
   }
 
   qname <- paste0("q", quantileX * 100)
-  quantile_name <- kpp("expr", qname)
+  quantile_name <- Stringendo::kpp("expr", qname)
 
   if (is.null(obj@misc[[quantile_name]])) {
-    iprint(
+    Stringendo::iprint(
       "Call: combined.obj <- calc.q99.Expression.and.set.all.genes(combined.obj, quantileX =",
       quantileX, " first )"
     )
   }
-  genes.HE <- which_names(obj@misc[[quantile_name]] > 0)
-  iprint("Pearson correlation is calculated for", length(genes.HE), "HE genes with expr.", qname, ": > 0.")
+  genes.HE <- CodeAndRoll2::which_names(obj@misc[[quantile_name]] > 0)
+  Stringendo::iprint("Pearson correlation is calculated for", length(genes.HE), "HE genes with expr.", qname, ": > 0.")
   tictoc::tic("sparse.cor")
   ls.cor <- sparse.cor(smat = t(expr.mat[genes.HE, cells.use]))
   tictoc::toc()
   ls.cor <- lapply(ls.cor, round, digits = 2)
 
-  slot__name <- kpp(slot.use, assay.use, quantile_name)
-  obj@misc[[kpp("cor", slot__name)]] <- ls.cor$"cor"
-  obj@misc[[kpp("cov", slot__name)]] <- ls.cor$"cov"
-  iprint("Stored under obj@misc$", kpp("cor", slot.use, assay.use), "or cov... .")
+  slot__name <- Stringendo::kpp(slot.use, assay.use, quantile_name)
+  obj@misc[[Stringendo::kpp("cor", slot__name)]] <- ls.cor$"cor"
+  obj@misc[[Stringendo::kpp("cov", slot__name)]] <- ls.cor$"cov"
+  Stringendo::iprint("Stored under obj@misc$", Stringendo::kpp("cor", slot.use, assay.use), "or cov... .")
   return(obj)
 }
 
@@ -3580,12 +3580,12 @@ plot.Gene.Cor.Heatmap <- function(
   expr.mat <- GetAssayData(slot = slot.use, assay = assay.use, object = obj)
 
   qname <- paste0("expr.q", quantileX * 100)
-  slotname_cor.mat <- kpp("cor", slot.use, assay.use, qname)
+  slotname_cor.mat <- Stringendo::kpp("cor", slot.use, assay.use, qname)
   cor.mat <- obj@misc[[slotname_cor.mat]]
 
   if (is.null(cor.mat)) {
-    iprint(slotname_cor.mat, " not found in @misc.")
-    iprint("Correlation slots present in @misc:", CodeAndRoll2::grepv(names(obj@misc), pattern = "^cor"))
+    Stringendo::iprint(slotname_cor.mat, " not found in @misc.")
+    Stringendo::iprint("Correlation slots present in @misc:", CodeAndRoll2::grepv(names(obj@misc), pattern = "^cor"))
 
     # Calculate --- --- --- --- ---
     if (calc.COR) {
@@ -3593,7 +3593,7 @@ plot.Gene.Cor.Heatmap <- function(
       genes.found <- check.genes(genes = genes)
       message(length(genes.found), " genes are found in the object.")
 
-      if (length(genes.found) > 200) iprint("Too many genes found in data, cor will be slow: ", length(genes.found))
+      if (length(genes.found) > 200) Stringendo::iprint("Too many genes found in data, cor will be slow: ", length(genes.found))
       ls.cor <- sparse.cor(t(expr.mat[genes.found, ]))
       cor.mat <- ls.cor$cor
     } else {
@@ -3602,7 +3602,7 @@ plot.Gene.Cor.Heatmap <- function(
   } else {
     print("Correlation is pre-calculated")
     genes.found <- intersect(genes, rownames(cor.mat))
-    iprint(length(genes.found), "genes are found in the correlation matrix.")
+    Stringendo::iprint(length(genes.found), "genes are found in the correlation matrix.")
     cor.mat <- cor.mat[genes.found, genes.found]
   }
 
@@ -3610,17 +3610,17 @@ plot.Gene.Cor.Heatmap <- function(
   # Filter --- --- --- --- --- ---
   diag(cor.mat) <- NaN
   corgene.names <- union(
-    which_names(rowMax(cor.mat) >= min.g.cor),
-    which_names(rowMin(cor.mat) <= -min.g.cor)
+    CodeAndRoll2::which_names(CodeAndRoll2::rowMax(cor.mat) >= min.g.cor),
+    CodeAndRoll2::which_names(CodeAndRoll2::rowMin(cor.mat) <= -min.g.cor)
   )
-  iprint(length(corgene.names), "genes are more (anti-)correlated than +/-:", min.g.cor)
+  Stringendo::iprint(length(corgene.names), "genes are more (anti-)correlated than +/-:", min.g.cor)
 
-  pname <- paste0("Pearson correlations of ", substitute_deparse(genes), "\n min.cor:", min.g.cor, " | ", assay.use, ".", slot.use)
+  pname <- paste0("Pearson correlations of ", Stringendo::substitute_deparse(genes), "\n min.cor:", min.g.cor, " | ", assay.use, ".", slot.use)
   o.heatmap <- pheatmap::pheatmap(cor.mat[corgene.names, corgene.names], main = pname, cutree_rows = cutRows, cutree_cols = cutCols, ...)
   MarkdownReports::wplot_save_pheatmap(o.heatmap, plotname = make.names(pname))
 
   # return values
-  maxCorrz <- rowMax(cor.mat)[corgene.names]
+  maxCorrz <- CodeAndRoll2::rowMax(cor.mat)[corgene.names]
   names(maxCorrz) <- corgene.names
   dput(maxCorrz)
 }
@@ -3912,7 +3912,7 @@ check.genes <- function(
       message(
         "\n", length(missingGenes), " or ",
         Stringendo::percentage_formatter(length(missingGenes) / length(genes)),
-        " genes not found in the data, e.g: ", kppc(head(missingGenes, n = 10))
+        " genes not found in the data, e.g: ", Stringendo::kppc(head(missingGenes, n = 10))
       )
     }
 
@@ -4032,7 +4032,7 @@ AddNewAnnotation <- function(
   obj = obj,
   source = "RNA_snn_res.0.5", named.list.of.identities = ls.Subset.ClusterLists
 ) {
-  NewID <- df.col.2.named.vector(obj[[source]])
+  NewID <- CodeAndRoll2::df.col.2.named.vector(obj[[source]])
 
   for (i in 1:length(named.list.of.identities)) {
     lx <- as.character(named.list.of.identities[[i]])
@@ -4080,13 +4080,13 @@ whitelist.subset.ls.Seurat <- function(
   dsets <- table(df.cell.whitelist[, 1])
 
   ls.orig.idents <- lapply(lapply(ls.Seurat, getMetadataColumn, ColName.metadata = "orig.ident"), unique)
-  stopif(any(sapply(ls.orig.idents, l) == length(ls.Seurat)), message = "Some ls.Seurat objects have 1+ orig identity.")
+  Stringendo::stopif(any(sapply(ls.orig.idents, l) == length(ls.Seurat)), message = "Some ls.Seurat objects have 1+ orig identity.")
 
   dsets.in.lsSeu <- unlist(ls.orig.idents)
   isMathced <- all(dsets.in.lsSeu == names(dsets)) # Stop if either ls.Seurat OR the metadata has identities not found in the other, in the same order.
-  stopif(!isMathced, message = paste(
+  Stringendo::stopif(!isMathced, message = paste(
     "either ls.Seurat OR the metadata has identities not found in the other, or they are not in same order.",
-    kpps(dsets.in.lsSeu), "vs.", kpps(names(dsets))
+    Stringendo::kpps(dsets.in.lsSeu), "vs.", Stringendo::kpps(names(dsets))
   ))
 
   # identX <- ls.orig.idents[[1]]
@@ -4106,7 +4106,7 @@ whitelist.subset.ls.Seurat <- function(
     ls.obj[[i]] <- subset(x = ls.obj[[i]], cells = cell.whitelist)
   }
   cells.after <- sapply(ls.obj, ncol)
-  iprint("cells.before", cells.before, "cells.after", cells.after)
+  Stringendo::iprint("cells.before", cells.before, "cells.after", cells.after)
   return(ls.obj)
 }
 
@@ -4143,15 +4143,15 @@ FindCorrelatedGenes <- function(
 ) {
   tictoc::tic("FindCorrelatedGenes")
   AssayData <- GetAssayData(object = obj, assay = assay, slot = slot)
-  matrix_mod <- iround(as.matrix(AssayData))
+  matrix_mod <- CodeAndRoll2::iround(as.matrix(AssayData))
   if (HEonly) {
     idx.pass <- (matrixStats::rowSums2(matrix_mod > minExpr) > minCells)
-    pc_TRUE(idx.pass)
+    CodeAndRoll2::pc_TRUE(idx.pass)
     matrix_mod <- matrix_mod[which(idx.pass), ]
   }
   geneExpr <- as.numeric(matrix_mod[gene, ])
   correlations <- apply(matrix_mod, 1, cor, geneExpr)
-  topGenes <- trail(sort(correlations, decreasing = TRUE), N = trailingNgenes)
+  topGenes <- CodeAndRoll2::trail(sort(correlations, decreasing = TRUE), N = trailingNgenes)
   tictoc::toc()
   MarkdownReports::wbarplot(head(topGenes, n = 25))
   topGenes
@@ -4304,7 +4304,7 @@ RenameGenesSeurat <- function(obj = ls.Seurat[[i]],
     layers <- Layers(obj@assays[[assay]])
     slots_found <- slots %in% layers
     stopifnot(any(slots_found))
-    warnifnot("Not all slots present in the object - all(slots_found)" = all(slots_found))
+    Stringendo::warnifnot("Not all slots present in the object - all(slots_found)" = all(slots_found))
     slots <- intersect(slots, layers)
   }
 
@@ -4318,10 +4318,10 @@ RenameGenesSeurat <- function(obj = ls.Seurat[[i]],
   }
 
   LayersFound <- SeuratObject::Layers(obj@assays[[assay]])
-  iprint("Present: ", sort(LayersFound))
+  Stringendo::iprint("Present: ", sort(LayersFound))
 
   slots <- sort(intersect(slots, LayersFound))
-  iprint("Replaced: ", slots)
+  Stringendo::iprint("Replaced: ", slots)
 
   for (slotX in slots) {
     print(slotX)
@@ -4377,7 +4377,7 @@ RenameGenesSeurat <- function(obj = ls.Seurat[[i]],
     rownames(assayobj@features@.Data) <- newnames
     nrX <- length(rownames(assayobj@features@.Data))
   } else {
-    iprint("length feature.list", length(feature.list), "length newnames", length(newnames))
+    Stringendo::iprint("length feature.list", length(feature.list), "length newnames", length(newnames))
     stop()
   }
 
@@ -4502,7 +4502,7 @@ RemoveGenesSeurat <- function(obj = ls.Seurat[[i]], symbols2remove = c("TOP2A"))
 #' @export
 HGNC.EnforceUnique <- function(updatedSymbols) {
   NGL <- updatedSymbols[, 3]
-  if (any.duplicated(NGL)) {
+  if (CodeAndRoll2::any.duplicated(NGL)) {
     updatedSymbols[, 3] <- make.unique(NGL)
     "Unique names are enforced by suffixing .1, .2, etc."
   }
@@ -4587,7 +4587,7 @@ PlotUpdateStats <- function(mat = UpdateStatMat, column.names = c("Updated (%)",
   HGNC.UpdateStatistics <- mat[, column.names, drop = FALSE]
   HGNC.UpdateStatistics[, "Updated (%)"] <- 100 * HGNC.UpdateStatistics[, "Updated (%)"]
   colnames(HGNC.UpdateStatistics) <- c("Gene Symbols updated (% of Total Genes)", "Number of Gene Symbols updated")
-  lll <- wcolorize(vector = rownames(HGNC.UpdateStatistics))
+  lll <- MarkdownHelpers::wcolorize(vector = rownames(HGNC.UpdateStatistics))
   MarkdownReports::wplot(HGNC.UpdateStatistics,
     col = lll,
     xlim = c(0, max(HGNC.UpdateStatistics[, 1])),
@@ -4669,14 +4669,14 @@ Convert10Xfolders <- function(
 
   compress_level <- .map_preset_to_compress_level(preset)
 
-  finOrig <- ReplaceRepeatedSlashes(list.dirs.depth.n(InputDir, depth = depth))
+  finOrig <- Stringendo::ReplaceRepeatedSlashes(list.dirs.depth.n(InputDir, depth = depth))
   fin <- CodeAndRoll2::grepv(x = finOrig, pattern = folderPattern, perl = regex)
 
   message(length(fin), " samples found.")
 
   samples <- basename(list.dirs(InputDir, recursive = FALSE))
   if (sort_alphanumeric) samples <- gtools::mixedsort(samples)
-  iprint("Samples:", samples)
+  Stringendo::iprint("Samples:", samples)
 
   if (!length(fin) > 0) {
     stop(paste("No subfolders found with pattern", folderPattern, "in dirs like: ", finOrig[1:3]))
@@ -4722,38 +4722,38 @@ Convert10Xfolders <- function(
     if (writeCBCtable) {
       CBCs <- t(t(colnames(seu)))
       colnames(CBCs) <- "CBC"
-      ReadWriter::write.simple.tsv(input_df = CBCs, manual_file_name = sppp(fnameIN, suffix, "CBC"), manual_directory = InputDir)
+      ReadWriter::write.simple.tsv(input_df = CBCs, manual_file_name = Stringendo::sppp(fnameIN, suffix, "CBC"), manual_directory = InputDir)
     }
 
     if (save_empty_droplets & suffix == "raw") {
       # Select and save empty droplets (the Soup)
 
       path_filtered <- gsub(x = pathIN, pattern = "/raw_feature_", replacement = "/filtered_feature_")
-      fnp_filtered <- spps(path_filtered, "barcodes.tsv.gz")
+      fnp_filtered <- Stringendo::spps(path_filtered, "barcodes.tsv.gz")
 
 
       if (file.exists(fnp_filtered)) {
-        SoupDir <- spps(InputDir, "Soup")
+        SoupDir <- Stringendo::spps(InputDir, "Soup")
         dir.create(SoupDir)
 
-        CBCs_HQ <- read.simple.vec(fnp_filtered)
+        CBCs_HQ <- ReadWriter::read.simple.vec(fnp_filtered)
 
         CBC_empty_drops <- setdiff(colnames(seu), CBCs_HQ)
         nr.empty.droplets <- length(CBC_empty_drops)
         umi_per_CBC <- colSums(seu@assays$RNA@layers$counts)
-        pct.empty.droplets.max10umis <- pc_TRUE(umi_per_CBC < 11)
+        pct.empty.droplets.max10umis <- CodeAndRoll2::pc_TRUE(umi_per_CBC < 11)
         message("We have ", nr.empty.droplets, " empty droplets, ", pct.empty.droplets.max10umis, " of which have max 10 umis.")
-        FNM <- sppp("nr.empty.droplets", fnameIN, nr.empty.droplets)
+        FNM <- Stringendo::sppp("nr.empty.droplets", fnameIN, nr.empty.droplets)
         ReadWriter::write.simple.vec(nr.empty.droplets, manual_file_name = FNM, manual_directory = SoupDir)
 
         obj_empty_drops <- subset(seu, cells = CBC_empty_drops)
 
-        f_path_out_ED <- Stringendo::ParseFullFilePath(path = SoupDir, file_name = sppp("obj.empty.droplets", fnameIN, nr.empty.droplets), extension = ext)
+        f_path_out_ED <- Stringendo::ParseFullFilePath(path = SoupDir, file_name = Stringendo::sppp("obj.empty.droplets", fnameIN, nr.empty.droplets), extension = ext)
         qs2::qs_save(object = obj_empty_drops, file = f_path_out_ED, nthreads = nthreads, compress_level = compress_level)
 
         # save the bulk RNA counts of the empty droplets
         Soup.Bulk.RNA <- rowSums(count_matrix[, CBC_empty_drops])
-        f_path_out_Bulk <- Stringendo::ParseFullFilePath(path = SoupDir, file_name = sppp("Soup.Bulk.RNA", fnameIN), extension = "qs")
+        f_path_out_Bulk <- Stringendo::ParseFullFilePath(path = SoupDir, file_name = Stringendo::sppp("Soup.Bulk.RNA", fnameIN), extension = "qs")
         qs2::qs_save(object = Soup.Bulk.RNA, file = f_path_out_Bulk, nthreads = nthreads, compress_level = compress_level)
         ReadWriter::write.simple.tsv(Soup.Bulk.RNA, suffix = fnameIN, manual_directory = SoupDir)
       }
@@ -4799,23 +4799,23 @@ ConvertDropSeqfolders <- function(
   useVroom = TRUE, col_types.vroom = list("GENE" = "c", .default = "d"),
   min.cells = 10, min.features = 200, updateHGNC = TRUE, ShowStats = TRUE, minDimension = 10, overwrite = FALSE
 ) {
-  InputDir <- FixPath(InputDir)
+  InputDir <- Stringendo::FixPath(InputDir)
   fin <- list.dirs(InputDir, recursive = FALSE)
   fin <- CodeAndRoll2::grepv(x = fin, pattern = folderPattern, perl = FALSE)
 
   for (i in 1:length(fin)) {
     print(i)
-    pathIN <- FixPath(fin[i])
+    pathIN <- Stringendo::FixPath(fin[i])
     print(pathIN)
     fnameIN <- basename(fin[i])
     subdir <- paste0(InputDir, fnameIN)
-    fnameOUT <- ppp(subdir, "min.cells", min.cells, "min.features", min.features, "Rds")
+    fnameOUT <- Stringendo::ppp(subdir, "min.cells", min.cells, "min.features", min.features, "Rds")
     print(fnameOUT)
     if (!overwrite) {
       OutFile <- list.files(InputDir, pattern = basename(fnameOUT), recursive = TRUE)
       if (length(OutFile) > 0) {
         if (grepl(pattern = ".Rds$", OutFile, perl = TRUE)) {
-          iprint("      RDS OBJECT ALREADY EXISTS.")
+          Stringendo::iprint("      RDS OBJECT ALREADY EXISTS.")
           next
         }
       } # if length
@@ -4824,16 +4824,16 @@ ConvertDropSeqfolders <- function(
     stopifnot(length(CountTable) == 1)
     count_matrix <- if (useVroom) {
       stopifnot("Package 'vroom' must be installed to use this function." = require("vroom"))
-      vroom::vroom(file = kpps(subdir, CountTable), col_types = col_types.vroom)
+      vroom::vroom(file = Stringendo::kpps(subdir, CountTable), col_types = col_types.vroom)
     } else {
-      readr::read_tsv(file = kpps(subdir, CountTable))
+      readr::read_tsv(file = Stringendo::kpps(subdir, CountTable))
     }
 
     if (nrow(count_matrix) < minDimension | ncol(count_matrix) < minDimension) {
-      iprint("")
-      iprint("      EXPRESSION MATRIX TOO SMALL.", nrow(count_matrix), "x", ncol(count_matrix), ". Not processed.")
+      Stringendo::iprint("")
+      Stringendo::iprint("      EXPRESSION MATRIX TOO SMALL.", nrow(count_matrix), "x", ncol(count_matrix), ". Not processed.")
     } else {
-      count_matrix <- FirstCol2RowNames(count_matrix)[, -1] # remove 1st "Cell column" # https://github.com/vertesy/SEO/issues/63
+      count_matrix <- ReadWriter::FirstCol2RowNames(count_matrix)[, -1] # remove 1st "Cell column" # https://github.com/vertesy/SEO/issues/63
       seu <- CreateSeuratObject(
         counts = count_matrix, project = fnameIN,
         min.cells = min.cells, min.features = min.features
@@ -4881,7 +4881,7 @@ LoadAllSeurats <- function(
   sort_alphanumeric = TRUE
 ) {
   tictoc::tic("LoadAllSeurats")
-  InputDir <- FixPath(InputDir)
+  InputDir <- Stringendo::FixPath(InputDir)
 
   print(file.pattern)
   use_rds <- grepl(pattern = "Rds", x = file.pattern) && !grepl(pattern = "qs", x = file.pattern)
@@ -4896,7 +4896,7 @@ LoadAllSeurats <- function(
   if (sort_alphanumeric) fin <- gtools::mixedsort(fin)
 
 
-  ls.Seu <- list.fromNames(fin)
+  ls.Seu <- CodeAndRoll2::list.fromNames(fin)
   for (i in 1:length(fin)) {
     print(fin[i])
     FNP <- paste0(InputDir, fin.orig[i])
@@ -5022,7 +5022,7 @@ read10x <- function(dir) {
 #' @export
 isave.RDS <- function(
   obj, prefix = NULL, suffix = NULL, inOutDir = TRUE,
-  project = getProject(),
+  project = CodeAndRoll2::getProject(),
   alternative_path_rdata = paste0("~/Dropbox (VBC)/Abel.IMBA/AnalysisD/_RDS.files/", basename(OutDir)),
   homepath = if (Sys.info()[1] == "Darwin") "~/" else "/users/abel.vertesy/",
   showMemObject = TRUE, saveParams = TRUE,
@@ -5040,7 +5040,7 @@ isave.RDS <- function(
     try(obj@misc$p <- p, silent = TRUE)
     try(obj@misc$all.genes <- all.genes, silent = TRUE)
   }
-  fnameBase <- kppu(prefix, substitute_deparse(obj), project, suffix, idate(Format = "%Y.%m.%d_%H.%M"))
+  fnameBase <- Stringendo::kppu(prefix, Stringendo::substitute_deparse(obj), project, suffix, Stringendo::idate(Format = "%Y.%m.%d_%H.%M"))
   fnameBase <- trimws(fnameBase, whitespace = "_")
   FNN <- paste0(path_rdata, fnameBase, ".Rds")
   FNN <- gsub(pattern = "~/", replacement = homepath, x = FNN)
@@ -5116,7 +5116,7 @@ xsave <- function(
   prefix = NULL,
   nthreads = if (object.size(obj) < 1e7) 1 else .getNrCores(12),
   preset = "high",
-  project = getProject(),
+  project = CodeAndRoll2::getProject(),
   dir = if (exists("OutDir")) OutDir else getwd(),
   showMemObject = TRUE,
   saveParams = if (exists("p")) TRUE else FALSE, # save allGenes and paramList
@@ -5136,21 +5136,21 @@ xsave <- function(
   # check if the object is a Seurat object
   obj_is_seurat <- inherits(obj, "Seurat")
   if (obj_is_seurat) {
-    annot.suffix <- kpp(ncol(obj), "cells")
+    annot.suffix <- Stringendo::kpp(ncol(obj), "cells")
   } else {
     saveParams <- FALSE
-    annot.suffix <- if (is.list(obj)) kppd("ls", length(obj)) else NULL
+    annot.suffix <- if (is.list(obj)) Stringendo::kppd("ls", length(obj)) else NULL
   }
 
-  if (!isFALSE(saveParams)) message("paramList: ", if (exists("paramList")) paste(substitute_deparse(paramList), length(paramList), " elements.") else " not provided.")
+  if (!isFALSE(saveParams)) message("paramList: ", if (exists("paramList")) paste(Stringendo::substitute_deparse(paramList), length(paramList), " elements.") else " not provided.")
   if (!isFALSE(saveParams)) message("allGenes: ", if (exists("allGenes")) " found as global variable." else " not provided.")
 
   try(tictoc::tic("xsave"), silent = TRUE)
   if (showMemObject & v) try(memory.biggest.objects(), silent = TRUE)
 
-  fnameBase <- trimws(kppu(
+  fnameBase <- trimws(Stringendo::kppu(
     prefix, as.character(substitute(obj)), annot.suffix, suffix, project,
-    idate(Format = "%Y.%m.%d_%H.%M")
+    Stringendo::idate(Format = "%Y.%m.%d_%H.%M")
   ), whitespace = "_")
 
   FNN <- paste0(dir, fnameBase, ".qs")
@@ -5217,11 +5217,11 @@ xread <- function(file,
   obj <- qs2::qs_read(file = file, nthreads = nthreads, ...)
 
   report <- if (is(obj, "Seurat")) {
-    kppws("Seurat object with", ncol(obj), "cells &", ncol(obj@meta.data), "meta columns.")
+    Stringendo::kppws("Seurat object with", ncol(obj), "cells &", ncol(obj@meta.data), "meta columns.")
   } else if (is.list(obj)) {
-    kppws("A list of:", length(obj))
+    Stringendo::kppws("A list of:", length(obj))
   } else {
-    kppws("Length of:", length(obj))
+    Stringendo::kppws("Length of:", length(obj))
   }
   message(report)
 
@@ -5372,11 +5372,11 @@ xread2 <- function(path,
   obj <- qs2::qs_read(file = path, nthreads = nthreads, ...)
 
   report <- if (is(obj, "Seurat")) {
-    kppws("with", ncol(obj), "cells &", ncol(obj@meta.data), "metadata columns.")
+    Stringendo::kppws("with", ncol(obj), "cells &", ncol(obj@meta.data), "metadata columns.")
   } else if (is.list(obj)) {
-    kppws("is a list of:", length(obj))
+    Stringendo::kppws("is a list of:", length(obj))
   } else {
-    kppws("of length:", length(obj))
+    Stringendo::kppws("of length:", length(obj))
   }
 
   if ("Seurat" %in% is(obj)) {
@@ -5404,7 +5404,7 @@ xread2 <- function(path,
     }
   }
 
-  iprint(is(obj)[1], report)
+  Stringendo::iprint(is(obj)[1], report)
   try(tictoc::toc(), silent = TRUE)
   invisible(obj)
 }
@@ -5442,11 +5442,11 @@ isave.image <- function(
   if (showMemObject) {
     try(memory.biggest.objects(), silent = TRUE)
   }
-  fname <- Stringendo::kollapse(path_rdata, "/", idate(), ..., ".Rdata")
+  fname <- Stringendo::kollapse(path_rdata, "/", Stringendo::idate(), ..., ".Rdata")
   print(fname)
   if (nchar(fname) > 2000) stop()
   save.image(file = fname, compress = FALSE)
-  iprint("Saved, being compressed", fname)
+  Stringendo::iprint("Saved, being compressed", fname)
   system(paste("gzip", options, fname), wait = FALSE) # execute in the background
 }
 
@@ -5470,11 +5470,11 @@ qsave.image <- function(
 ) {
   tictoc::tic("qsave.image")
 
-  fname <- Stringendo::kollapse(getwd(), "/", basename(OutDir), idate(), ..., ".Rdata")
+  fname <- Stringendo::kollapse(getwd(), "/", basename(OutDir), Stringendo::idate(), ..., ".Rdata")
   print(fname)
   if (nchar(fname) > 2000) stop()
   save.image(file = fname, compress = FALSE)
-  iprint("Saved, being compressed", fname)
+  Stringendo::iprint("Saved, being compressed", fname)
   system(paste("gzip", options, fname), wait = FALSE) # execute in the background
   cat(tictoc::toc)
 }
@@ -5502,17 +5502,17 @@ find10XoutputFolders <- function(root_dir, subdir, recursive = TRUE) {
   outs_dirs <- c()
   for (i in seq_along(subdir)) {
     path <- file.path(root_dir, subdir[i])
-    printProgress(i, length(subdir), "Processing subdirectory")
+    CodeAndRoll2::printProgress(i, length(subdir), "Processing subdirectory")
 
-    iprint("Searching in:", path)
+    Stringendo::iprint("Searching in:", path)
     found_dirs <- fs::dir_ls(path, recurse = recursive, glob = "*/outs", type = "directory")
-    iprint(length(found_dirs), "output folders found.")
+    Stringendo::iprint(length(found_dirs), "output folders found.")
     outs_dirs <- c(outs_dirs, found_dirs)
   }
 
   # Replace root_dir in the paths with an empty string for printing
   outs_print <- gsub(paste0("^", root_dir, "/?"), "", outs_dirs)
-  iprint(length(outs_dirs), outs_print)
+  Stringendo::iprint(length(outs_dirs), outs_print)
 
   return(outs_dirs)
 }
@@ -5591,7 +5591,7 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
                         out_dir_prefix = "SoupStatistics",
                         add_custom_class = FALSE, pattern_custom = "\\.RabV$",
                         ls.Alpha = 1) {
-  iprint("library_name:", library_name)
+  Stringendo::iprint("library_name:", library_name)
 
   stopifnot( # Check input
     is.character(CellRanger_outs_Dir), dir.exists(CellRanger_outs_Dir),
@@ -5599,7 +5599,7 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
     is.numeric(ls.Alpha)
   )
 
-  if (add_custom_class) iprint("pattern_custom:", pattern_custom)
+  if (add_custom_class) Stringendo::iprint("pattern_custom:", pattern_custom)
 
   # The regular expression `[[:alnum:]_]+(?=/outs/)` matches one or more alphanumeric characters or
   # underscores that are followed by the `/outs/` portion in the string. It ensures that the desired
@@ -5619,11 +5619,11 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   # Identify raw and filtered files ___________________________________
   path.raw <- file.path(CellRanger_outs_Dir, grep(x = Subfolders_10X_outs, pattern = "^raw_*", value = TRUE))
   path.filt <- file.path(CellRanger_outs_Dir, grep(x = Subfolders_10X_outs, pattern = "^filt_*", value = TRUE))
-  CR.matrices <- list.fromNames(c("raw", "filt"))
+  CR.matrices <- CodeAndRoll2::list.fromNames(c("raw", "filt"))
 
   # Adapter for Markdownreports background variable "OutDir"
   OutDirBac <- if (exists("OutDir")) OutDir else getwd()
-  OutDir <- file.path(CellRanger_outs_Dir, paste0(kpp(out_dir_prefix, library_name)))
+  OutDir <- file.path(CellRanger_outs_Dir, paste0(Stringendo::kpp(out_dir_prefix, library_name)))
 
   MarkdownReports::create_set_OutDir(OutDir)
   MarkdownHelpers::ww.assign_to_global("OutDir", OutDir, 1)
@@ -5647,7 +5647,7 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   print("Profiling the soup")
   GEMs.all <- CR.matrices$"raw"@Dimnames[[2]]
   GEMs.cells <- CR.matrices$"filt"@Dimnames[[2]]
-  iprint("There are", length(GEMs.all), "GEMs sequenced, and", length(GEMs.cells), "are cells among those.")
+  Stringendo::iprint("There are", length(GEMs.all), "GEMs sequenced, and", length(GEMs.cells), "are cells among those.")
   EmptyDroplets.and.Cells <- c("EmptyDroplets" = length(GEMs.all) - length(GEMs.cells), "Cells" = length(GEMs.cells))
   ggExpress::qbarplot(EmptyDroplets.and.Cells, label = EmptyDroplets.and.Cells, palette_use = "npg", col = 1:2, ylab = "GEMs")
 
@@ -5666,9 +5666,9 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   )
   colnames(Soup.VS.Cells.Av.Exp)
   idx.HE <- rowSums(Soup.VS.Cells.Av.Exp) > 10
-  pc_TRUE(idx.HE)
+  CodeAndRoll2::pc_TRUE(idx.HE)
   Soup.VS.Cells.Av.Exp <- Soup.VS.Cells.Av.Exp[idx.HE, ]
-  idim(Soup.VS.Cells.Av.Exp)
+  CodeAndRoll2::idim(Soup.VS.Cells.Av.Exp)
   Soup.VS.Cells.Av.Exp.log10 <- log10(Soup.VS.Cells.Av.Exp + 1)
 
   # ggplot prepare ___________________________________
@@ -5687,14 +5687,14 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   Class[grep("^LINC", HGNC)] <- "LINC"
   Class[grep("^AC", HGNC)] <- "AC"
   Class[grep("^AL", HGNC)] <- "AL"
-  if (add_custom_class) Class[grep(pattern_custom, HGNC)] <- ReplaceSpecialCharacters(pattern_custom, remove_dots = TRUE)
+  if (add_custom_class) Class[grep(pattern_custom, HGNC)] <- Stringendo::ReplaceSpecialCharacters(pattern_custom, remove_dots = TRUE)
   Nr.of.Genes.per.Class <- table(Class)
 
 
   ggExpress::qpie(Nr.of.Genes.per.Class)
   Soup.VS.Cells.Av.Exp.gg$Class <- Class
 
-  fname <- kpp("Soup.VS.Cells.Av.Exp.GeneClasses", library_name, "pdf")
+  fname <- Stringendo::kpp("Soup.VS.Cells.Av.Exp.GeneClasses", library_name, "pdf")
   pgg <-
     ggplot(
       Soup.VS.Cells.Av.Exp.gg |>
@@ -5718,15 +5718,15 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
     print(pr)
     HP.thr <- 200 * pr / quantiles[2]
     idx.HE2 <- rowSums(Soup.VS.Cells.Av.Exp) > HP.thr
-    pc_TRUE(idx.HE2)
+    CodeAndRoll2::pc_TRUE(idx.HE2)
 
-    fname <- kpp("Soup.VS.Cells.Av.Exp.quantile", pr, library_name, "pdf")
+    fname <- Stringendo::kpp("Soup.VS.Cells.Av.Exp.quantile", pr, library_name, "pdf")
 
     Outlier <- idx.HE2 &
       (cell.rate < quantile(cell.rate, probs = pr) |
         soup.rate < quantile(soup.rate, probs = pr))
 
-    pc_TRUE(Outlier)
+    CodeAndRoll2::pc_TRUE(Outlier)
     sum(Outlier)
     HP.thr.mod <- HP.thr
     while (sum(Outlier) > 40) {
@@ -5755,11 +5755,11 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   PC.mRNA.in.Soup <- sum(CR.matrices$"soup") / sum(CR.matrices$"raw")
   PC.mRNA.in.Cells <- 100 * sum(CR.matrices$"filt") / sum(CR.matrices$"raw")
   MarkdownReports::wbarplot(
-    variable = PC.mRNA.in.Cells, col = "seagreen", plotname = kppd("PC.mRNA.in.Cells", library_name),
+    variable = PC.mRNA.in.Cells, col = "seagreen", plotname = Stringendo::kppd("PC.mRNA.in.Cells", library_name),
     ylim = c(0, 100), ylab = "% mRNA in cells",
     sub = "% mRNA is more meaningful than % reads reported by CR"
   )
-  barplot_label(
+  MarkdownReports::barplot_label(
     barplotted_variable = PC.mRNA.in.Cells,
     labels = Stringendo::percentage_formatter(PC.mRNA.in.Cells / 100, digitz = 2),
     TopOffset = 10
@@ -5770,13 +5770,13 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   Soup.GEMs.top.Genes <- 100 * head(sort(CR.matrices$"soup.rel.RC", decreasing = TRUE), n = 20)
 
   MarkdownReports::wbarplot(Soup.GEMs.top.Genes,
-    plotname = kppd("Soup.GEMs.top.Genes", library_name),
+    plotname = Stringendo::kppd("Soup.GEMs.top.Genes", library_name),
     ylab = "% mRNA in the Soup",
     sub = paste("Within the", library_name, "dataset"),
     tilted_text = TRUE,
     ylim = c(0, max(Soup.GEMs.top.Genes) * 1.5)
   )
-  barplot_label(
+  MarkdownReports::barplot_label(
     barplotted_variable = Soup.GEMs.top.Genes,
     labels = Stringendo::percentage_formatter(Soup.GEMs.top.Genes / 100, digitz = 2),
     TopOffset = -.5, srt = 90, cex = .75
@@ -5814,12 +5814,12 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   Soup.GEMs.top.Genes.summarized <- 100 * soupProfile.summarized[1:NrColumns2Show] / CR.matrices$"soup.total.sum"
   maxx <- max(Soup.GEMs.top.Genes.summarized)
   MarkdownReports::wbarplot(Soup.GEMs.top.Genes.summarized,
-    plotname = kppd("Soup.GEMs.top.Genes.summarized", library_name),
+    plotname = Stringendo::kppd("Soup.GEMs.top.Genes.summarized", library_name),
     ylab = "% mRNA in the Soup", ylim = c(0, maxx + 3),
     sub = paste("Within the", library_name, "dataset"),
     tilted_text = TRUE, col = ccc
   )
-  barplot_label(
+  MarkdownReports::barplot_label(
     barplotted_variable = Soup.GEMs.top.Genes.summarized,
     srt = 45, labels = Stringendo::percentage_formatter(Soup.GEMs.top.Genes.summarized / 100, digitz = 2),
     TopOffset = -1.5
@@ -5830,12 +5830,12 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
 
   maxx <- max(Absolute.fraction.soupProfile.summarized)
   MarkdownReports::wbarplot(Absolute.fraction.soupProfile.summarized,
-    plotname = kppd("Absolute.fraction.soupProfile.summarized", library_name),
+    plotname = Stringendo::kppd("Absolute.fraction.soupProfile.summarized", library_name),
     ylab = "% of mRNA in cells", ylim = c(0, maxx * 1.33),
     sub = paste(Stringendo::percentage_formatter(PC.mRNA.in.Soup), "of mRNA counts are in the Soup, in the dataset ", library_name),
     tilted_text = TRUE, col = ccc
   )
-  barplot_label(
+  MarkdownReports::barplot_label(
     barplotted_variable = Absolute.fraction.soupProfile.summarized,
     srt = 45, labels = Stringendo::percentage_formatter(Absolute.fraction.soupProfile.summarized / 100, digitz = 2)
     # formatC(Absolute.fraction.soupProfile.summarized, format="f", big.mark = " ", digits = 0)
@@ -5846,13 +5846,13 @@ plotTheSoup <- function(CellRanger_outs_Dir = "~/Data/114593/114593",
   Soup.GEMs.top.Genes.non.summarized <- 100 * sort(genes.non.Above, decreasing = TRUE)[1:20] / CR.matrices$"soup.total.sum"
   maxx <- max(Soup.GEMs.top.Genes.non.summarized)
   MarkdownReports::wbarplot(Soup.GEMs.top.Genes.non.summarized,
-    plotname = kppd("Soup.GEMs.top.Genes.non.summarized", library_name),
+    plotname = Stringendo::kppd("Soup.GEMs.top.Genes.non.summarized", library_name),
     ylab = "% mRNA in the Soup",
     sub = paste("Within the", library_name, "dataset"),
     tilted_text = TRUE, col = "#BF3100",
     ylim = c(0, maxx * 1.5)
   )
-  barplot_label(
+  MarkdownReports::barplot_label(
     barplotted_variable = Soup.GEMs.top.Genes.non.summarized,
     labels = Stringendo::percentage_formatter(Soup.GEMs.top.Genes.non.summarized / 100, digitz = 2),
     TopOffset = -maxx * 0.2, srt = 90, cex = .75
@@ -5899,11 +5899,11 @@ jJaccardIndexVec <- function(A = 1:3, B = 2:4) length(intersect(A, B)) / length(
 #' @importFrom Stringendo percentage_formatter
 jPairwiseJaccardIndexList <- function(lsG = ls_genes) {
   if (length(names(lsG)) < length(lsG)) {
-    iprint("Gene lists were not (all) named, now renamed as:")
-    names(lsG) <- ppp("dataset", 1:length(lsG))
+    Stringendo::iprint("Gene lists were not (all) named, now renamed as:")
+    names(lsG) <- Stringendo::ppp("dataset", 1:length(lsG))
     print(names(lsG))
   }
-  m <- matrix.fromNames(rowname_vec = names(lsG), colname_vec = names(lsG))
+  m <- CodeAndRoll2::matrix.fromNames(rowname_vec = names(lsG), colname_vec = names(lsG))
   n.sets <- length(lsG)
   for (r in 1:n.sets) {
     # print(Stringendo::percentage_formatter(r/n.sets))
@@ -5942,7 +5942,7 @@ jPresenceMatrix <- function(string_list = lst(a = 1:3, b = 2:5, c = 4:9, d = -1:
     unnest(cols = "value") |>
     count(name, value) |>
     spread(value, n, fill = 0)
-  df.presence2 <- FirstCol2RowNames(df.presence)
+  df.presence2 <- ReadWriter::FirstCol2RowNames(df.presence)
   return(t(df.presence2))
 }
 
@@ -5992,7 +5992,7 @@ jJaccardIndexBinary <- function(x, y) {
 #' @export
 #' @importFrom Stringendo percentage_formatter
 jPairwiseJaccardIndex <- function(binary.presence.matrix = df.presence) {
-  m <- matrix.fromNames(rowname_vec = colnames(binary.presence.matrix), colname_vec = colnames(binary.presence.matrix))
+  m <- CodeAndRoll2::matrix.fromNames(rowname_vec = colnames(binary.presence.matrix), colname_vec = colnames(binary.presence.matrix))
   n.sets <- ncol(binary.presence.matrix)
   for (r in 1:n.sets) {
     print(Stringendo::percentage_formatter(r / n.sets))
@@ -6046,8 +6046,8 @@ compareVarFeaturesAndRanks <- function(
   stopifnot(!is.null(obj1), !is.null(obj2))
   stopifnot(is(obj1, "Seurat"), is(obj2, "Seurat"))
 
-  name1 <- substitute_deparse(obj1)
-  name2 <- substitute_deparse(obj2)
+  name1 <- Stringendo::substitute_deparse(obj1)
+  name2 <- Stringendo::substitute_deparse(obj2)
 
   var.genes1 <- Seurat::VariableFeatures(obj1)
   var.genes2 <- Seurat::VariableFeatures(obj2)
@@ -6055,7 +6055,7 @@ compareVarFeaturesAndRanks <- function(
   if (plot_venn) {
     variable.genes.overlap <- list(var.genes1, var.genes2)
     names(variable.genes.overlap) <- c(name1, name2)
-    ggExpress::qvenn(list = variable.genes.overlap, suffix = sppp(suffix, c(name1, name2)))
+    ggExpress::qvenn(list = variable.genes.overlap, suffix = Stringendo::sppp(suffix, c(name1, name2)))
   }
 
   nr_genes1 <- length(var.genes1)
@@ -6112,7 +6112,7 @@ compareVarFeaturesAndRanks <- function(
     print(plt)
   }
 
-  unique.genes <- symdiff(var.genes1, var.genes2)
+  unique.genes <- CodeAndRoll2::symdiff(var.genes1, var.genes2)
   names(unique.genes) <- paste0("Unique.", c(name1, name2))
   return(list(
     "common_genes" = common_genes,
@@ -6315,11 +6315,11 @@ compareVarFeaturesAndRanks <- function(
   } # else use scaledFeatures
 
   pcs <- .getNrPCs(obj)
-  regressionInfo <- kppc(regressionVariables)
+  regressionInfo <- Stringendo::kppc(regressionVariables)
   reg <- if (!is.null(regressionVariables)) paste0(regressionInfo, " regressed out") else "no regression"
   if (return.as.name) {
-    reg <- ReplaceSpecialCharacters(RemoveWhitespaces(reg, replacement = "."))
-    tag <- kpp(scaledFeatures, "ScaledFeatures", pcs, "PCs", reg, suffix)
+    reg <- Stringendo::ReplaceSpecialCharacters(Stringendo::RemoveWhitespaces(reg, replacement = "."))
+    tag <- Stringendo::kpp(scaledFeatures, "ScaledFeatures", pcs, "PCs", reg, suffix)
   } else {
     tag <- paste0(scaledFeatures, " ScaledFeatures | ", pcs, " PCs | ", reg, " ", suffix)
   }

--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -88,7 +88,7 @@ PlotFilters <- function(
   above.ribo = par.ls$"thr.hp.ribo",
   below.nFeature_RNA = if ("quantile.thr.lp.nFeature_RNA" %in% names(par.ls)) par.ls$"quantile.thr.lp.nFeature_RNA" else par.ls$"thr.lp.nFeature_RNA",
   above.nFeature_RNA = par.ls$"thr.hp.nFeature_RNA",
-  subdir = FixPlotName(
+  subdir = Stringendo::FixPlotName(
     "Filtering.plots",
     "mito", par.ls$"thr.hp.mito", par.ls$"thr.lp.mito",
     "ribo", par.ls$"thr.hp.ribo", par.ls$"thr.lp.ribo",
@@ -120,12 +120,12 @@ PlotFilters <- function(
 
   MarkdownHelpers::llprint(
     "We filtered for high quality cells based on the number of genes detected [", above.nFeature_RNA, ";", below.nFeature_RNA,
-    "] and the fraction of mitochondrial [", percentage_formatter(above.mito), ";", percentage_formatter(below.mito),
-    "] and ribosomal [", percentage_formatter(above.ribo), ";", percentage_formatter(below.ribo), "] reads."
+    "] and the fraction of mitochondrial [", Stringendo::percentage_formatter(above.mito), ";", Stringendo::percentage_formatter(below.mito),
+    "] and ribosomal [", Stringendo::percentage_formatter(above.ribo), ";", Stringendo::percentage_formatter(below.ribo), "] reads."
   )
 
   theme_set(theme.used)
-  OutDir <- FixPath(parentdir, subdir)
+  OutDir <- Stringendo::FixPath(parentdir, subdir)
 
   print(subdir)
 
@@ -144,7 +144,7 @@ PlotFilters <- function(
       nFtr_valid <- nFtr[nFtr > above.nFeature_RNA] # restrict to high-quality cells, otherwise the quantile may be Influenced by the amount of junk in the library.
 
       below.nFeature_RNA <- floor(quantile(nFtr_valid, probs = qval))
-      message(pc_TRUE(nFtr_valid < below.nFeature_RNA, NumberAndPC = TRUE, suffix = paste("cells below thr.", below.nFeature_RNA, "at quantile:", qval)))
+      message(CodeAndRoll2::pc_TRUE(nFtr_valid < below.nFeature_RNA, NumberAndPC = TRUE, suffix = paste("cells below thr.", below.nFeature_RNA, "at quantile:", qval)))
       stopifnot(below.nFeature_RNA > above.nFeature_RNA)
     }
 
@@ -175,14 +175,14 @@ PlotFilters <- function(
     )
 
     boolean_LC_cells <- metadata_df$"nFeature_RNA" <= above.nFeature_RNA
-    LQ <- pc_TRUE(boolean_LC_cells)
-    Doublets <- pc_TRUE(metadata_df$"nFeature_RNA"[!boolean_LC_cells] >= below.nFeature_RNA)
+    LQ <- CodeAndRoll2::pc_TRUE(boolean_LC_cells)
+    Doublets <- CodeAndRoll2::pc_TRUE(metadata_df$"nFeature_RNA"[!boolean_LC_cells] >= below.nFeature_RNA)
 
     A <- ggplot(data = metadata_df, aes(x = nFeature_RNA, fill = colour.thr.nFeature)) +
       geom_histogram(binwidth = 100) +
       ggtitle(paste(
         "Cells between", above.nFeature_RNA, "and", below.nFeature_RNA,
-        "UMIs are selected \n(", pc_TRUE(filt.nFeature_RNA), "), with",
+        "UMIs are selected \n(", CodeAndRoll2::pc_TRUE(filt.nFeature_RNA), "), with",
         LQ, "low-quality and", Doublets, "doublet cells excluded."
       )) +
       scale_y_log10() +
@@ -194,8 +194,8 @@ PlotFilters <- function(
 
     B <- ggplot2::ggplot(metadata_df, aes(x = nFeature_RNA, y = percent.mito)) +
       ggplot2::ggtitle(paste(
-        "Cells below", percentage_formatter(below.mito),
-        "mito reads are selected \n(with A:", pc_TRUE(filt.nFeature_RNA & filt.below.mito), ")"
+        "Cells below", Stringendo::percentage_formatter(below.mito),
+        "mito reads are selected \n(with A:", CodeAndRoll2::pc_TRUE(filt.nFeature_RNA & filt.below.mito), ")"
       )) +
       ggplot2::geom_point(
         alpha = transparency, size = cex, show.legend = FALSE,
@@ -211,9 +211,9 @@ PlotFilters <- function(
 
     C <- ggplot(metadata_df, aes(x = nFeature_RNA, y = percent.ribo)) +
       ggtitle(paste(
-        "Cells below", percentage_formatter(below.ribo),
+        "Cells below", Stringendo::percentage_formatter(below.ribo),
         "ribo reads are selected \n(with A:",
-        pc_TRUE(filt.nFeature_RNA & filt.below.ribo), ")"
+        CodeAndRoll2::pc_TRUE(filt.nFeature_RNA & filt.below.ribo), ")"
       )) +
       geom_point(
         alpha = transparency, size = cex, show.legend = FALSE,
@@ -230,7 +230,7 @@ PlotFilters <- function(
     D <- ggplot(metadata_df, aes(x = percent.ribo, y = percent.mito)) +
       ggtitle(paste(
         "Final: All cells w/o extreme values are selected \n(with A,B,C:",
-        pc_TRUE(filt.nFeature_RNA & filt.below.mito & filt.below.ribo), ")"
+        CodeAndRoll2::pc_TRUE(filt.nFeature_RNA & filt.below.mito & filt.below.ribo), ")"
       )) +
       geom_point(
         alpha = transparency, size = cex, show.legend = FALSE,
@@ -278,12 +278,12 @@ PlotFilters <- function(
 
 
     # Save figure
-    fname <- kpps(OutDir, FixPlotName("Filtering.thresholds", suffices[i], filetype))
+    fname <- Stringendo::kpps(OutDir, Stringendo::FixPlotName("Filtering.thresholds", suffices[i], filetype))
     cowplot::save_plot(filename = fname, plot = px, base_height = 15)
     stopifnot(file.exists(fname))
   } # for
   # _________________________________________________________________________________________________
-  create_set_OutDir(parentdir)
+  MarkdownReports::create_set_OutDir(parentdir)
 }
 
 
@@ -370,7 +370,7 @@ scPlotPCAvarExplained <- function(obj = combined.obj,
   pct <- scCalcPCAVarExplained(obj)
   if (use.MarkdownReports) {
     MarkdownReports::wbarplot(pct, xlab = "Principal Components", ylab = "% of variation explained", ...)
-    barplot_label(round(pct, digits = 2), barplotted_variable = pct, cex = .5)
+    MarkdownReports::barplot_label(round(pct, digits = 2), barplotted_variable = pct, cex = .5)
   } else {
     ggExpress::qbarplot(
       vec = pct, plotname = plotname, subtitle = sub,
@@ -429,11 +429,11 @@ PercentInTranscriptome <- function(
 
   total.Expr <- sort(rowSums(m.expr), decreasing = TRUE)
   relative.total.Expr <- total.Expr / sum(total.Expr)
-  print(head(iround(100 * relative.total.Expr), n = n.genes.barplot))
+  print(head(CodeAndRoll2::iround(100 * relative.total.Expr), n = n.genes.barplot))
 
   Relative.of.Total.Gene.Expression <- relative.total.Expr * 100
 
-  qhistogram(Relative.of.Total.Gene.Expression,
+  ggExpress::qhistogram(Relative.of.Total.Gene.Expression,
     logX = FALSE, logY = TRUE,
     plotname = "Gene expression as fraction of all transcripts *UMI's)",
     subtitle = "Percentage in RNA-counts",
@@ -444,8 +444,8 @@ PercentInTranscriptome <- function(
     ...
   )
 
-  Highest.Expressed.Genes <- head(iround(100 * relative.total.Expr), n = n.genes.barplot)
-  qbarplot(Highest.Expressed.Genes,
+  Highest.Expressed.Genes <- head(CodeAndRoll2::iround(100 * relative.total.Expr), n = n.genes.barplot)
+  ggExpress::qbarplot(Highest.Expressed.Genes,
     plotname = "Percentage of highest expressed genes",
     subtitle = "Total, in RNA-counts",
     xlab = "",
@@ -497,14 +497,14 @@ plotGeneExpressionInBackgroundHist <- function(
 
   GEX.Counts.total <- rowSums(GEX.Counts)
   genes.expression <- GEX.Counts.total[gene]
-  mean.expr <- iround(mean(GEX.Counts[gene, ]))
+  mean.expr <- CodeAndRoll2::iround(mean(GEX.Counts[gene, ]))
 
   suffx <- if (slot == "counts") "raw" else "normalised, logtransformed"
   (pname <- paste(gene, "and the", suffx, "transcript count distribution"))
 
   ggExpress::qhistogram(GEX.Counts.total,
     vline = genes.expression, logX = TRUE, w = w, h = h,
-    subtitle = paste("It belong to the top", pc_TRUE(GEX.Counts.total > genes.expression), "of genes (black line). Mean expr:", mean.expr),
+    subtitle = paste("It belong to the top", CodeAndRoll2::pc_TRUE(GEX.Counts.total > genes.expression), "of genes (black line). Mean expr:", mean.expr),
     plotname = pname, xlab = "Total Transcripts in Dataset", ylab = "Number of Genes",
     ...
   )
@@ -592,14 +592,14 @@ plotGeneExprHistAcrossCells <- function(
   }
 
   # Create annotation
-  CPT <- paste("layer:", layerX, "| assay:", assay, "| cutoff at", iround(thr_expr))
+  CPT <- paste("layer:", layerX, "| assay:", assay, "| cutoff at", CodeAndRoll2::iround(thr_expr))
 
   # Add a subtitle with the number of genes and the expression threshold
-  SUBT <- filter_HP(SummedExpressionPerCell, threshold = thr_expr, return_conclusion = TRUE, plot.hist = FALSE)
+  SUBT <- MarkdownHelpers::filter_HP(SummedExpressionPerCell, threshold = thr_expr, return_conclusion = TRUE, plot.hist = FALSE)
 
   if (aggregate) {
-    SUBT <- paste0(SUBT, "\n", length(genes), " genes summed up, e.g: ", kppc(head(genes)))
-    TTL <- kppd(prefix, plotname[1], suffix)
+    SUBT <- paste0(SUBT, "\n", length(genes), " genes summed up, e.g: ", Stringendo::kppc(head(genes)))
+    TTL <- Stringendo::kppd(prefix, plotname[1], suffix)
   } else {
     TTL <- trimws(paste(prefix, plotname[length(plotname)], paste(genes), suffix))
   }
@@ -623,7 +623,7 @@ plotGeneExprHistAcrossCells <- function(
     pobj <- pobj +
       ggplot2::geom_vline(xintercept = thr_expr[-1], col = 2, lty = 2, lwd = 1) +
       ggplot2::labs(caption = "Red line marks original estimate")
-    ggExpress::qqSave(ggobj = pobj, title = sppp(TTL, "w.orig")) # , ext = '.png'
+    ggExpress::qqSave(ggobj = pobj, title = Stringendo::sppp(TTL, "w.orig")) # , ext = '.png'
   }
 
 
@@ -726,7 +726,7 @@ PctCellsAboveX <- function(
   # 7. Re-group for box mode __________________________________
   if (box) {
     from_to <- split(df[[ident.box]], df[[ident]])
-    from_to <- list.2.replicated.name.vec(from_to)
+    from_to <- CodeAndRoll2::list.2.replicated.name.vec(from_to)
     pct_vec <- pct_vec[names(from_to)]
     pct_list <- split(pct_vec, f = from_to)
   }
@@ -734,17 +734,17 @@ PctCellsAboveX <- function(
   # 8. Plotting (your exact original code) ____________________
   if (plot) {
     if (is.null(caption)) {
-      caption <- pc_TRUE(is.na(pct_vec),
+      caption <- CodeAndRoll2::pc_TRUE(is.na(pct_vec),
         suffix = "of idents yielded NA/NaN & excluded from plot."
       )
     }
 
     TTL <- paste("Percentage of Cells Above Threshold for", feature)
     STL <- paste("Cells above threshold for", feature, "above", threshold)
-    SFX <- ppp(feature, "by", ident, "thr", threshold, "subset_ident", subset_ident)
+    SFX <- Stringendo::ppp(feature, "by", ident, "thr", threshold, "subset_ident", subset_ident)
 
     if (box) {
-      pobj <- qboxplot(
+      pobj <- ggExpress::qboxplot(
         pct_list,
         add = "dotplot",
         xlab.angle = 45,
@@ -758,9 +758,9 @@ PctCellsAboveX <- function(
         ...
       )
     } else {
-      pobj <- qbarplot(
+      pobj <- ggExpress::qbarplot(
         pct_vec,
-        label = percentage_formatter(pct_vec),
+        label = Stringendo::percentage_formatter(pct_vec),
         plotname = TTL,
         subtitle = STL,
         caption = caption,
@@ -979,7 +979,7 @@ scBarplot.CellFractions <- function(
   obj = combined.obj,
   downsample = FALSE,
   min.nr.sampled.cells = 200,
-  plotname = kppws("Cell proportions of", fill.by, "by", group.by),
+  plotname = Stringendo::kppws("Cell proportions of", fill.by, "by", group.by),
   suffix = NULL,
   prefix = NULL,
   sub_title = suffix,
@@ -1011,14 +1011,14 @@ scBarplot.CellFractions <- function(
     is.numeric(min_frequency) && length(min_frequency) == 1 && min_frequency >= 0 && min_frequency < 1, # min_frequency must be between 0 and 1
     group.by %in% colnames(obj@meta.data), # group.by must be a valid column in the meta.data slot of the Seurat object
     fill.by %in% colnames(obj@meta.data), # fill.by must be a valid column in the meta.data slot of the Seurat object
-    "To many categories for X axis (group.by)" = nr.unique(obj@meta.data[, group.by]) < 100
+    "To many categories for X axis (group.by)" = CodeAndRoll2::nr.unique(obj@meta.data[, group.by]) < 100
   )
 
   META <- obj@meta.data
 
   if (is.null(w)) {
-    categ_X <- nr.unique(META[, group.by])
-    categ_Y <- nr.unique(META[, fill.by])
+    categ_X <- CodeAndRoll2::nr.unique(META[, group.by])
+    categ_Y <- CodeAndRoll2::nr.unique(META[, fill.by])
     w <- ceiling(max(7, categ_Y / 4, categ_X / 1.5))
   }
 
@@ -1041,7 +1041,7 @@ scBarplot.CellFractions <- function(
     }
 
     # Update plot name and caption to reflect downsampling
-    plotname <- kpp(plotname, "downsampled")
+    plotname <- Stringendo::kpp(plotname, "downsampled")
     pname.suffix <- "(downsampled)"
 
     capt.suffix <- paste0(
@@ -1052,10 +1052,10 @@ scBarplot.CellFractions <- function(
 
 
   # Construct the caption based on downsampling and minimum frequency
-  PFX <- if (show_numbers) "Numbers denote # cells." else percentage_formatter(min.pct, prefix = "Labeled above")
+  PFX <- if (show_numbers) "Numbers denote # cells." else Stringendo::percentage_formatter(min.pct, prefix = "Labeled above")
   caption_ <- paste("Top: Total cells per bar. |", PFX, capt.suffix)
 
-  if (min_frequency > 0) caption_ <- paste(caption_, "\nCategories <", percentage_formatter(min_frequency), "are shown together as 'Other'")
+  if (min_frequency > 0) caption_ <- paste(caption_, "\nCategories <", Stringendo::percentage_formatter(min_frequency), "are shown together as 'Other'")
   pname_ <- paste(plotname, pname.suffix)
 
 
@@ -1087,12 +1087,12 @@ scBarplot.CellFractions <- function(
 
     categories <- unique(prop_table$"category")
     n.categories <- length(categories)
-    message(n.categories, " Y-categories present: ", kppc(sort(categories)))
+    message(n.categories, " Y-categories present: ", Stringendo::kppc(sort(categories)))
 
     # join the proportions back to the original data
     META <- left_join(META, prop_table, by = fill.by)
 
-    subtt <- kppws(group.by, "|", ncol(obj), "cells", sub_title)
+    subtt <- Stringendo::kppws(group.by, "|", ncol(obj), "cells", sub_title)
 
 
     if (downsample) {
@@ -1170,10 +1170,10 @@ scBarplot.CellFractions <- function(
     if (save_plot) {
       # sfx <- shorten_clustering_names(group.by)
       sfx <- if (!is.null(suffix)) suffix else NULL
-      if (min_frequency) sfx <- sppp(sfx, min_frequency)
-      qqSave(
-        ggobj = pl, title = FixPlotName(plotname), also.pdf = also.pdf, w = w, h = h,
-        suffix = sppp(sfx, "fr.barplot")
+      if (min_frequency) sfx <- Stringendo::sppp(sfx, min_frequency)
+      ggExpress::qqSave(
+        ggobj = pl, title = Stringendo::FixPlotName(plotname), also.pdf = also.pdf, w = w, h = h,
+        suffix = Stringendo::sppp(sfx, "fr.barplot")
         # , ...
       )
     } # save_plot
@@ -1187,7 +1187,7 @@ scBarplot.CellFractions <- function(
 
   if (save_table) {
     ReadWriter::write.simple.xlsx(CT_freq_sc,
-      filename = sppp(FixPlotName(plotname), suffix, "fr.barplot")
+      filename = Stringendo::sppp(Stringendo::FixPlotName(plotname), suffix, "fr.barplot")
       # suffix = sppp(FixPlotName(plotname), "fr.barplot")
     )
   }
@@ -1260,7 +1260,7 @@ scBarplot.CellsPerCluster <- function(
   lbl <- if (isFALSE(label)) {
     NULL
   } else if (label == "percent") {
-    percentage_formatter(cell.per.cluster / sum(cell.per.cluster), digitz = 2)
+    Stringendo::percentage_formatter(cell.per.cluster / sum(cell.per.cluster), digitz = 2)
   } else if (isTRUE(label)) {
     cell.per.cluster
   } else {
@@ -1268,14 +1268,14 @@ scBarplot.CellsPerCluster <- function(
   }
 
   min.PCT.cells <- min.cells / ncol(obj)
-  message("min cell thr: ", min.cells, " corresponding to min: ", percentage_formatter(min.PCT.cells))
+  message("min cell thr: ", min.cells, " corresponding to min: ", Stringendo::percentage_formatter(min.PCT.cells))
 
   n.clusters <- length(cell.per.cluster)
   nr.cells.per.cl <- table(obj[[ident]][, 1], useNA = "ifany")
 
-  SBT <- pc_TRUE(nr.cells.per.cl < min.cells,
+  SBT <- CodeAndRoll2::pc_TRUE(nr.cells.per.cl < min.cells,
     NumberAndPC = TRUE,
-    suffix = paste("of identities are below:", min.cells, "cells, or", percentage_formatter(min.PCT.cells), "of all cells.")
+    suffix = paste("of identities are below:", min.cells, "cells, or", Stringendo::percentage_formatter(min.PCT.cells), "of all cells.")
   )
 
   color <- if (is.null(col)) 1:n.clusters else col
@@ -1287,7 +1287,7 @@ scBarplot.CellsPerCluster <- function(
   pl <- ggExpress::qbarplot(cell.per.cluster,
     plotname = plotname,
     subtitle = paste0(sub, "\n", SBT),
-    suffix = kpp(ident, ncol(obj), "c", suffix),
+    suffix = Stringendo::kpp(ident, ncol(obj), "c", suffix),
     col = color,
     caption = .parseBasicObjStats(obj = obj),
     xlab.angle = 45,
@@ -1373,7 +1373,7 @@ scBarplot.FractionAboveThr <- function(
     } else {
       metacol[, value.col] < thrX
     }
-  total_average <- iround(100 * mean(pass))
+  total_average <- CodeAndRoll2::iround(100 * mean(pass))
 
   df_2vec <-
     if (above) {
@@ -1386,18 +1386,18 @@ scBarplot.FractionAboveThr <- function(
   (v.fr_n_cells_above <- 100 * deframe(df_2vec))
 
   tag <- if (above) "above" else "below"
-  if (is.null(label)) label <- percentage_formatter(deframe(df_2vec), digitz = 2)
+  if (is.null(label)) label <- Stringendo::percentage_formatter(deframe(df_2vec), digitz = 2)
 
   pname <- paste("Pc. cells", tag, value.col, "of", thrX)
   ggobj <- ggExpress::qbarplot(v.fr_n_cells_above,
     label = label,
     plotname = pname,
-    filename = FixPlotName(kpp(pname, id.col, ext)),
+    filename = Stringendo::FixPlotName(Stringendo::kpp(pname, id.col, ext)),
     suffix = suffix,
     subtitle = subtitle,
     caption = paste(
-      "Overall average (black line):", iround(total_average), "% |",
-      substitute_deparse(obj),
+      "Overall average (black line):", CodeAndRoll2::iround(total_average), "% |",
+      Stringendo::substitute_deparse(obj),
     ),
     xlab.angle = 45,
     xlab = "Clusters",
@@ -1497,7 +1497,7 @@ scPieClusterDistribution <- function(obj = combined.obj, ident = GetClusteringRu
   print(cluster_sizes)
 
   # Create pie chart
-  qpie(cluster_sizes, caption = .parseBasicObjStats(obj), subtitle = ident)
+  ggExpress::qpie(cluster_sizes, caption = .parseBasicObjStats(obj), subtitle = ident)
 }
 
 
@@ -1996,7 +1996,7 @@ qFeatureScatter <- function(
   logX = FALSE, logY = FALSE,
   ...
 ) {
-  plotname <- kpp(feature1, "VS", feature2)
+  plotname <- Stringendo::kpp(feature1, "VS", feature2)
   p <- FeatureScatter(object = obj, feature1 = feature1, feature2 = feature2, ...) +
     ggtitle(paste("Correlation", plotname)) +
     theme_linedraw()
@@ -2139,7 +2139,7 @@ qSeuViolin <- function(
 
     if (col_is_metacolname) {
       col_long <- as.factor(unlist(obj[[colors]]))
-      colors <- as.factor.numeric(sapply(split(col_long, split_col), unique))
+      colors <- CodeAndRoll2::as.factor.numeric(sapply(split(col_long, split_col), unique))
     }
   }
 
@@ -2165,8 +2165,8 @@ qSeuViolin <- function(
   if (!is.null(legend.pos)) p.obj <- p.obj + theme(legend.position = legend.pos)
 
   # Save the plot.
-  TTL <- ppp(as.character(feature), "by", ident, suffix)
-  qqSave(p.obj, title = TTL, suffix = ppp(flag.nameiftrue(logY), "violin"), w = w, h = h, limitsize = FALSE)
+  TTL <- Stringendo::ppp(as.character(feature), "by", ident, suffix)
+  ggExpress::qqSave(p.obj, title = TTL, suffix = Stringendo::ppp(Stringendo::flag.nameiftrue(logY), "violin"), w = w, h = h, limitsize = FALSE)
   if (show_plot) p.obj
 }
 
@@ -2272,7 +2272,7 @@ qUMAP <- function(
   if (!isFALSE(caption)) gg.obj <- gg.obj + ggplot2::labs(caption = caption)
 
   if (save.plot) {
-    fname <- ww.FnP_parser(sppp(prefix, toupper(reduction), feature, assay, paste0(ncol(obj), "c"), suffix), if (PNG) "png" else "pdf")
+    fname <- MarkdownHelpers::ww.FnP_parser(Stringendo::sppp(prefix, toupper(reduction), feature, assay, paste0(ncol(obj), "c"), suffix), if (PNG) "png" else "pdf")
     try(save_plot(filename = fname, plot = gg.obj, base_height = h, base_width = w)) # , ncol = 1, nrow = 1
   }
   return(gg.obj)
@@ -2341,7 +2341,7 @@ clUMAP <- function(
   label.cex = 7,
   h = 7, w = NULL,
   nr.cols = NULL,
-  plotname = ppp(toupper(reduction), ident),
+  plotname = Stringendo::ppp(toupper(reduction), ident),
   cols = NULL,
   palette = c("alphabet", "alphabet2", "glasbey", "polychrome", "stepped")[4],
   max.cols.for.std.palette = 7,
@@ -2386,7 +2386,7 @@ clUMAP <- function(
   IdentFound <- (ident %in% colnames(obj@meta.data))
   if (!IdentFound) {
     ident <- GetClusteringRuns(obj = obj, pat = "_res.*[0,1]\\.[0-9]$")[1]
-    iprint("Identity not found. Plotting", ident, "\n")
+    Stringendo::iprint("Identity not found. Plotting", ident, "\n")
   }
   identity <- obj[[ident]]
   Ident_categories <- unique(identity[, 1])
@@ -2398,8 +2398,8 @@ clUMAP <- function(
     if (!(all(highlight.clusters %in% identity[, 1]))) {
       MSG <- paste(
         "Some clusters not found in the object! Missing:",
-        kppc(setdiff(highlight.clusters, Ident_categories)), "\nFrom:\n",
-        kppc(sort(Ident_categories))
+        Stringendo::kppc(setdiff(highlight.clusters, Ident_categories)), "\nFrom:\n",
+        Stringendo::kppc(sort(Ident_categories))
       )
       warning(MSG, immediate. = TRUE)
     }
@@ -2408,12 +2408,12 @@ clUMAP <- function(
     stopifnot("minimum 10 cells are needed" = sum(idx.ok) > 10)
 
     highlight.these <- rownames(identity)[idx.ok]
-    PCT <- percentage_formatter(length(highlight.these) / ncol(obj), suffix = "or")
+    PCT <- Stringendo::percentage_formatter(length(highlight.these) / ncol(obj), suffix = "or")
 
     # Annotation to subtitle _________________________________________________________________
     sub2 <- paste(PCT, length(highlight.these), "cells in", ident, "are highlighted")
-    sub3 <- paste("Highlighted clusters:", kppc(highlight.clusters))
-    sub <- if (is.null(sub)) ppnl(sub2, sub3) else ppnl(sub, sub2, sub3)
+    sub3 <- paste("Highlighted clusters:", Stringendo::kppc(highlight.clusters))
+    sub <- if (is.null(sub)) Stringendo::ppnl(sub2, sub3) else Stringendo::ppnl(sub, sub2, sub3)
 
     # title <- kpipe(ident, )
   } else {
@@ -2445,7 +2445,7 @@ clUMAP <- function(
 
   # Plot _________________________________________________________________________________________
   if (NtCategs > MaxCategThrHP) {
-    iprint("Too many categories (", NtCategs, ") in ", ident, "- use qUMAP for continuous variables.")
+    Stringendo::iprint("Too many categories (", NtCategs, ") in ", ident, "- use qUMAP for continuous variables.")
   } else {
     if (length(unique(identity)) < MaxCategThrHP) {
       gg.obj <-
@@ -2473,8 +2473,8 @@ clUMAP <- function(
 
     # Save plot ___________________________________________________________
     if (save.plot) {
-      pname <- sppp(prefix, plotname, paste0(ncol(obj), "c"), suffix, sppp(highlight.clusters))
-      fname <- ww.FnP_parser(pname, if (PNG) "png" else "pdf")
+      pname <- Stringendo::sppp(prefix, plotname, paste0(ncol(obj), "c"), suffix, Stringendo::sppp(highlight.clusters))
+      fname <- MarkdownHelpers::ww.FnP_parser(pname, if (PNG) "png" else "pdf")
       try(save_plot(filename = fname, plot = gg.obj, base_height = h, base_width = w))
     }
     tictoc::toc()
@@ -2538,7 +2538,7 @@ umapHiLightSel <- function(obj = combined.obj,
   if (show_plot) print(pl)
 
   ggplot2::ggsave(
-    filename = extPNG(kollapse("cells", COI, collapseby = ".")),
+    filename = Stringendo::extPNG(Stringendo::kollapse("cells", COI, collapseby = ".")),
     height = h, width = w
   )
 }
@@ -2650,8 +2650,8 @@ multiFeaturePlot.A4 <- function(
 
   ParentDir <- OutDir
   if (is.null(foldername)) foldername <- "genes"
-  final.foldername <- FixPlotName(paste0(foldername, "-", plot.reduction, suffix))
-  if (subdir) create_set_SubDir(final.foldername, "/", verbose = FALSE)
+  final.foldername <- Stringendo::FixPlotName(paste0(foldername, "-", plot.reduction, suffix))
+  if (subdir) MarkdownReports::create_set_SubDir(final.foldername, "/", verbose = FALSE)
 
   if (is.null(names(list.of.genes))) subtitle.from.names <- FALSE
 
@@ -2659,7 +2659,7 @@ multiFeaturePlot.A4 <- function(
     genes = list.of.genes, obj = obj,
     assay.slot = intersectionAssay, makeuppercase = FALSE
   )
-  if (subtitle.from.names) names(list.of.genes.found) <- as.character(flip_value2name(list.of.genes)[list.of.genes.found])
+  if (subtitle.from.names) names(list.of.genes.found) <- as.character(CodeAndRoll2::flip_value2name(list.of.genes)[list.of.genes.found])
   DefaultAssay(obj) <- intersectionAssay
 
   if (!is.null(cex.min)) cex <- max(cex.min, cex)
@@ -2682,8 +2682,8 @@ multiFeaturePlot.A4 <- function(
   lsG <- CodeAndRoll2::split_vec_to_list_by_N(1:length(list.of.genes.found), by = nr.Row * nr.Col)
   for (i in 1:length(lsG)) {
     genes <- list.of.genes.found[lsG[[i]]]
-    iprint(i, genes)
-    plotname <- kpp(c(prefix, plot.reduction, i, genes, suffix, format))
+    Stringendo::iprint(i, genes)
+    plotname <- Stringendo::kpp(c(prefix, plot.reduction, i, genes, suffix, format))
 
     plot.list <- Seurat::FeaturePlot(
       object = obj, features = genes, reduction = plot.reduction, combine = FALSE,
@@ -2712,7 +2712,7 @@ multiFeaturePlot.A4 <- function(
   if (subdir) MarkdownReports::create_set_OutDir(ParentDir, verbose = FALSE)
   if (saveGeneList) {
     if (is.null(obj@misc$gene.lists)) obj@misc$gene.lists <- list()
-    obj@misc$gene.lists[[substitute_deparse(list.of.genes)]] <- list.of.genes.found
+    obj@misc$gene.lists[[Stringendo::substitute_deparse(list.of.genes)]] <- list.of.genes.found
     print("Genes saved under: obj@misc$gene.lists")
     return(obj)
   }
@@ -2821,8 +2821,8 @@ multiSingleClusterHighlightPlots.A4 <- function(
   for (i in 1:length(ls.Clust)) { # for each page
 
     clusters_on_this_page <- as.character(clusters[ls.Clust[[i]]])
-    iprint("page:", i, "| clusters", kppc(clusters_on_this_page))
-    (plotname <- kpp(c(prefix, plot.reduction, i, "clusters", ls.Clust[[i]], suffix, format)))
+    Stringendo::iprint("page:", i, "| clusters", Stringendo::kppc(clusters_on_this_page))
+    (plotname <- Stringendo::kpp(c(prefix, plot.reduction, i, "clusters", ls.Clust[[i]], suffix, format)))
 
     plot.list <- list()
     for (j in seq(clusters_on_this_page)) { # for each cluster
@@ -2884,12 +2884,12 @@ multiSingleClusterHighlightPlots.A4 <- function(
 #' @importFrom ggExpress qA4_grid_plot
 qClusteringUMAPS <- function(
   obj = combined.obj,
-  idents = na.omit.strip(GetClusteringRuns(obj)[1:4]),
+  idents = CodeAndRoll2::na.omit.strip(GetClusteringRuns(obj)[1:4]),
   prefix = "Clustering.UMAP.Res",
   suffix = "",
   nrow = 2, ncol = 2,
   w = 2 * 11.69, h = 2 * 8.27,
-  title = sppu(
+  title = Stringendo::sppu(
     prefix,
     as.numeric(stringr::str_extract(idents, "\\d+\\.\\d+$")),
     suffix
@@ -2902,7 +2902,7 @@ qClusteringUMAPS <- function(
   idents.found <- intersect(idents, colnames(obj@meta.data))
   n.found <- length(idents.found)
   stopifnot("None of the idents found" = n.found > 0)
-  message(kppws(n.found, " found of ", idents))
+  message(Stringendo::kppws(n.found, " found of ", idents))
 
   if (n.found > 5) {
     idents.found <- idents.found[1:4]
@@ -2970,7 +2970,7 @@ qGeneExpressionUMAPS <- function(
     "Only 4 features are allowed" = n.found < 5
   )
 
-  message(kppws(n.found, "found of", length(features), "features:", features))
+  message(Stringendo::kppws(n.found, "found of", length(features), "features:", features))
 
   px <- list(
     "A" = qUMAP(feature = features[1], save.plot = FALSE, obj = obj, caption = NULL, ...) + NoAxes(),
@@ -3030,7 +3030,7 @@ plotQUMAPsInAFolder <- function(genes, obj = combined.obj,
   )
 
   ParentDir <- OutDir
-  if (is.null(foldername)) foldername <- substitute_deparse(genes)
+  if (is.null(foldername)) foldername <- Stringendo::substitute_deparse(genes)
 
   MarkdownReports::create_set_SubDir(paste0(foldername, "-", plot.reduction), "/")
 
@@ -3101,11 +3101,11 @@ PlotTopGenesPerCluster <- function(
     order.by = order.by
   )
 
-  ls.topMarkers <- splitbyitsnames(topX.markers)
+  ls.topMarkers <- CodeAndRoll2::splitbyitsnames(topX.markers)
   for (i in 1:length(ls.topMarkers)) {
     multiFeaturePlot.A4(
-      list.of.genes = ls.topMarkers[[i]], obj = obj, subdir = TRUE, foldername = ppp("TopGenes.umaps"),
-      prefix = ppp("DEG.markers.res", cl_res, "cluster", names(ls.topMarkers)[i]),
+      list.of.genes = ls.topMarkers[[i]], obj = obj, subdir = TRUE, foldername = Stringendo::ppp("TopGenes.umaps"),
+      prefix = Stringendo::ppp("DEG.markers.res", cl_res, "cluster", names(ls.topMarkers)[i]),
       ...
     )
   }
@@ -3140,7 +3140,7 @@ qQC.plots.BrainOrg <- function(
   QC.Features = c("nFeature_RNA", "percent.ribo", "percent.mito", "nuclear.fraction", "percent.HGA"),
   prefix = "QC.markers.4.UMAP",
   suffix = "",
-  title = sppu(prefix, QC.Features, suffix),
+  title = Stringendo::sppu(prefix, QC.Features, suffix),
   nrow = 2, ncol = 2,
   ...
 ) {
@@ -3150,7 +3150,7 @@ qQC.plots.BrainOrg <- function(
   QC.Features.Found <- intersect(QC.Features, union(colnames(obj@meta.data), rownames(obj)))
   QC.Features.Found.in.meta <- intersect(QC.Features, colnames(obj@meta.data))
   n.found <- length(QC.Features.Found)
-  message(kppws(n.found, " found: ", QC.Features.Found))
+  message(Stringendo::kppws(n.found, " found: ", QC.Features.Found))
   stopifnot(n.found > 1)
 
 
@@ -3230,7 +3230,7 @@ qMarkerCheck.BrainOrg <- function(obj = combined.obj, custom.genes = FALSE,
   print(CodeAndRoll2::as_tibble_from_namedVec(Signature.Genes.Top16))
   multiFeaturePlot.A4(
     obj = obj, list.of.genes = Signature.Genes.Top16, layout = "tall",
-    foldername = sppp("Signature.Genes.Top16", suffix)
+    foldername = Stringendo::sppp("Signature.Genes.Top16", suffix)
   )
 }
 
@@ -3315,7 +3315,7 @@ FlipReductionCoordinates <- function(
     bac.slot <- paste0(reduction, dim, "d")
     if (length(obj@misc$reductions.backup[[bac.slot]])) {
       obj@misc$reductions.backup[[bac.slot]]@cell.embeddings <- coordinates
-      iprint(dim, "dimensional", reduction, "backup flipped too.")
+      Stringendo::iprint(dim, "dimensional", reduction, "backup flipped too.")
     }
   }
   return(obj)
@@ -3358,7 +3358,7 @@ AutoNumber.by.UMAP <- function(obj = combined.obj,
                                ident = GetClusteringRuns(obj = obj)[1],
                                plot = TRUE,
                                obj.version = obj@version) {
-  dim_name <- kppu(reduction, dim)
+  dim_name <- Stringendo::kppu(reduction, dim)
   if (obj.version < "5") dim_name <- toupper(dim_name)
   message("Obj. version: ", obj.version, " \ndimension name: ", dim_name)
   message("Resolution: ", ident)
@@ -3377,8 +3377,8 @@ AutoNumber.by.UMAP <- function(obj = combined.obj,
   OldLabel <- names(sort(MedianClusterCoordinate, decreasing = swap))
   NewLabel <- as.character(0:(length(MedianClusterCoordinate) - 1))
   NewMeta <- CodeAndRoll2::translate(vec = identX, old = OldLabel, new = NewLabel)
-  NewMetaCol <- kpp(ident, "ordered")
-  iprint("NewMetaCol:", NewMetaCol)
+  NewMetaCol <- Stringendo::kpp(ident, "ordered")
+  Stringendo::iprint("NewMetaCol:", NewMetaCol)
 
   obj[[NewMetaCol]] <- NewMeta
   if (plot) {
@@ -3432,7 +3432,7 @@ scEnhancedVolcano <- function(
   y = "p_val_adj",
   title = "DGEA",
   lab = rownames(toptable),
-  selectLab = trail(filterCodingGenes(lab), 10),
+  selectLab = CodeAndRoll2::trail(filterCodingGenes(lab), 10),
   min.p = 1e-50,
   max.l2fc = Inf,
   min.pct.cells = 0.1,
@@ -3484,7 +3484,7 @@ scEnhancedVolcano <- function(
   min.pct.cells <- toptable |>
     dplyr::select(pct.1, pct.2) |>
     as.matrix() |>
-    rowMax() |>
+    CodeAndRoll2::rowMax() |>
     min()
 
   # 3. Value Clipping ----------------------------------------------------------
@@ -3497,18 +3497,18 @@ scEnhancedVolcano <- function(
     "y contains no finite values" = any(is.finite(toptable[[y]]))
   )
 
-  toptable[[y]] <- clip.at.fixed.value(toptable[[y]], thr = min.p, above = FALSE)
+  toptable[[y]] <- CodeAndRoll2::clip.at.fixed.value(toptable[[y]], thr = min.p, above = FALSE)
 
   if (!identical(pCutoffCol, y)) {
-    toptable[[pCutoffCol]] <- clip.at.fixed.value(
+    toptable[[pCutoffCol]] <- CodeAndRoll2::clip.at.fixed.value(
       toptable[[pCutoffCol]],
       thr = min.p, above = FALSE
     )
   }
 
   if (max.l2fc < Inf) {
-    toptable[[x]] <- clip.at.fixed.value(toptable[[x]], thr = -max.l2fc, above = FALSE)
-    toptable[[x]] <- clip.at.fixed.value(toptable[[x]], thr = max.l2fc, above = TRUE)
+    toptable[[x]] <- CodeAndRoll2::clip.at.fixed.value(toptable[[x]], thr = -max.l2fc, above = FALSE)
+    toptable[[x]] <- CodeAndRoll2::clip.at.fixed.value(toptable[[x]], thr = max.l2fc, above = TRUE)
   }
 
   # 4. Subtitle Stats Generation -----------------------------------------------
@@ -3517,7 +3517,7 @@ scEnhancedVolcano <- function(
     enr_stats <- unlist(countRelevantEnrichments(
       df = toptable, logfc_col = x, pval_col = y, logfc_cutoff = FCcutoff, pval_cutoff = pCutoff
     ))
-    stat_info <- kppws("Genes", intermingle2vec(names(enr_stats), enr_stats), "(red)")
+    stat_info <- Stringendo::kppws("Genes", CodeAndRoll2::intermingle2vec(names(enr_stats), enr_stats), "(red)")
     subtitle <- paste0(
       stat_info, "\nCutoffs: max.p_adj: ", pCutoff, " | min.log2FC: ", FCcutoff,
       " | min.pct.cells: ", min.pct.cells
@@ -3544,7 +3544,7 @@ scEnhancedVolcano <- function(
   stopifnot("EnhancedVolcano must return a ggplot object" = inherits(pobj, "ggplot"))
 
   # 6. Save Plot ---------------------------------------------------------------
-  qqSave(
+  ggExpress::qqSave(
     ggobj = pobj, title = paste0("Volcano.", make.names(title), suffix),
     also.pdf = also.pdf, h = h, w = w
   )
@@ -3681,7 +3681,7 @@ scEnhancedVolcano <- function(
   lfc_enr <- min(lfc[lfc > 0])
   lfc_depl <- abs(max(lfc[lfc < 0]))
   estim_min_l2fc <- min(lfc_enr, lfc_depl)
-  return(iround(2^estim_min_l2fc))
+  return(CodeAndRoll2::iround(2^estim_min_l2fc))
 }
 
 
@@ -3833,7 +3833,7 @@ scGOEnrichment <- function(genes, universe = NULL,
 
   if (save) {
     xsave(go_results,
-      suffix = kpp("enr", nr_of_enr_terms, suffix),
+      suffix = Stringendo::kpp("enr", nr_of_enr_terms, suffix),
       showMemObject = FALSE, saveParams = FALSE, allGenes = FALSE
     )
   }
@@ -3941,7 +3941,7 @@ scBarplotEnrichr <- function(df.enrichment,
                              tag = "...",
                              universe = df.enrichment@universe,
                              title = paste("GO Enriched Terms", tag),
-                             subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+                             subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
                              caption = paste0(
                                "Input genes: ", length(df.enrichment@"gene"),
                                " | Enriched terms: ", nrow(df.enrichment),
@@ -3971,7 +3971,7 @@ scBarplotEnrichr <- function(df.enrichment,
 
   pobj <- pobj + ggplot2::labs(title = title, subtitle = subtitle, caption = caption)
 
-  if (save) qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+  if (save) ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
 
   return(pobj)
 }
@@ -4016,7 +4016,7 @@ scDotplotEnrichr <- function(
   tag = "...",
   universe = df.enrichment@universe,
   title = paste("GO Enriched Terms", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Input genes: ", length(df.enrichment@"gene"),
     " | Enriched terms: ", nrow(df.enrichment),
@@ -4085,7 +4085,7 @@ scDotplotEnrichr <- function(
       caption = caption
     )
 
-  if (save) qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+  if (save) ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
 
   return(pobj)
 }
@@ -4132,7 +4132,7 @@ scEmapplotEnrichr <- function(
   tag = "...",
   universe = df.enrichment@universe,
   title = paste("GO Enrichment Map", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Input genes: ", length(df.enrichment@"gene"),
     " | Enriched terms: ", nrow(df.enrichment),
@@ -4187,7 +4187,7 @@ scEmapplotEnrichr <- function(
     )
 
   if (save) {
-    qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+    ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
   }
 
   return(pobj)
@@ -4246,7 +4246,7 @@ scGeneConceptNetworkEnrichr <- function(
   tag = NULL,
   NULL_input = is.null(df.enrichment),
   title = paste("Gene-Concept Network", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Enriched terms: ", ifelse(NULL_input, 0, nrow(df.enrichment)),
     " | Shown: ", ifelse(NULL_input, 0, min(showCategory, nrow(df.enrichment))),
@@ -4334,7 +4334,7 @@ scGeneConceptNetworkEnrichr <- function(
 
 
   if (save) {
-    qqSave(
+    ggExpress::qqSave(
       pobj,
       title = title,
       w = w, h = h,
@@ -4383,7 +4383,7 @@ scBarplotEnrichr <- function(df.enrichment,
                              tag = "...",
                              universe = df.enrichment@universe,
                              title = paste("GO Enriched Terms", tag),
-                             subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+                             subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
                              caption = paste0(
                                "Input genes: ", length(df.enrichment@"gene"),
                                " | Enriched terms: ", nrow(df.enrichment),
@@ -4413,7 +4413,7 @@ scBarplotEnrichr <- function(df.enrichment,
 
   pobj <- pobj + ggplot2::labs(title = title, subtitle = subtitle, caption = caption)
 
-  if (save) qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+  if (save) ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
 
   return(pobj)
 }
@@ -4458,7 +4458,7 @@ scDotplotEnrichr <- function(
   tag = "...",
   universe = df.enrichment@universe,
   title = paste("GO Enriched Terms", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Input genes: ", length(df.enrichment@"gene"),
     " | Enriched terms: ", nrow(df.enrichment),
@@ -4527,7 +4527,7 @@ scDotplotEnrichr <- function(
       caption = caption
     )
 
-  if (save) qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+  if (save) ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
 
   return(pobj)
 }
@@ -4574,7 +4574,7 @@ scEmapplotEnrichr <- function(
   tag = "...",
   universe = df.enrichment@universe,
   title = paste("GO Enrichment Map", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Input genes: ", length(df.enrichment@"gene"),
     " | Enriched terms: ", nrow(df.enrichment),
@@ -4629,7 +4629,7 @@ scEmapplotEnrichr <- function(
     )
 
   if (save) {
-    qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
+    ggExpress::qqSave(pobj, title = title, w = w, h = h, also.pdf = also.pdf, save.obj = save.obj)
   }
 
   return(pobj)
@@ -4688,7 +4688,7 @@ scGeneConceptNetworkEnrichr <- function(
   tag = NULL,
   NULL_input = is.null(df.enrichment),
   title = paste("Gene-Concept Network", tag),
-  subtitle = kppws("Input: ", substitute_deparse(df.enrichment)),
+  subtitle = Stringendo::kppws("Input: ", Stringendo::substitute_deparse(df.enrichment)),
   caption = paste0(
     "Enriched terms: ", ifelse(NULL_input, 0, nrow(df.enrichment)),
     " | Shown: ", ifelse(NULL_input, 0, min(showCategory, nrow(df.enrichment))),
@@ -4776,7 +4776,7 @@ scGeneConceptNetworkEnrichr <- function(
 
 
   if (save) {
-    qqSave(
+    ggExpress::qqSave(
       pobj,
       title = title,
       w = w, h = h,
@@ -4993,7 +4993,7 @@ save2plots.A4 <- function(
   nrow = 2, ncol = 1,
   h = 11.69 * scale, w = 8.27 * scale, ...
 ) {
-  if (pname == FALSE) pname <- sppp(substitute_deparse(plot_list), suffix)
+  if (pname == FALSE) pname <- Stringendo::sppp(Stringendo::substitute_deparse(plot_list), suffix)
   p1 <- cowplot::plot_grid(
     plotlist = plot_list, nrow = nrow, ncol = ncol,
     labels = LETTERS[1:length(plot_list)], ...
@@ -5002,9 +5002,9 @@ save2plots.A4 <- function(
     theme(plot.background = element_rect(fill = "white", color = NA))
 
   print("Saved as:")
-  MarkdownHelpers::ww.FnP_parser(extPNG(pname))
+  MarkdownHelpers::ww.FnP_parser(Stringendo::extPNG(pname))
 
-  save_plot(plot = p1, filename = extPNG(pname), base_height = h, base_width = w)
+  save_plot(plot = p1, filename = Stringendo::extPNG(pname), base_height = h, base_width = w)
 }
 
 # _________________________________________________________________________________________________
@@ -5045,7 +5045,7 @@ save4plots.A4 <- function(
   h = 8.27 * scale, w = 11.69 * scale,
   ...
 ) {
-  if (pname == FALSE) pname <- sppp(substitute_deparse(plot_list), suffix)
+  if (pname == FALSE) pname <- Stringendo::sppp(Stringendo::substitute_deparse(plot_list), suffix)
   p1 <- cowplot::plot_grid(
     plotlist = plot_list, nrow = nrow, ncol = ncol,
     labels = LETTERS[1:length(plot_list)], ...
@@ -5054,9 +5054,9 @@ save4plots.A4 <- function(
   p1 <- cowplot::ggdraw(p1) +
     theme(plot.background = element_rect(fill = "white", color = NA))
 
-  iprint("Saved as:", pname)
-  MarkdownHelpers::ww.FnP_parser(extPNG(pname))
-  save_plot(plot = p1, filename = extPNG(pname), base_height = h, base_width = w)
+  Stringendo::iprint("Saved as:", pname)
+  MarkdownHelpers::ww.FnP_parser(Stringendo::extPNG(pname))
+  save_plot(plot = p1, filename = Stringendo::extPNG(pname), base_height = h, base_width = w)
 }
 
 
@@ -5090,7 +5090,7 @@ qqSaveGridA4 <- function(
   fname = "Fractions.Organoid-to-organoid variation.png", ...
 ) {
   stopifnot(NrPlots %in% c(2, 4))
-  iprint(NrPlots, "plots found,", plots, "are saved.")
+  Stringendo::iprint(NrPlots, "plots found,", plots, "are saved.")
   pg.cf <- cowplot::plot_grid(plotlist = plotlist[plots], nrow = 2, ncol = NrPlots / 2, labels = LETTERS[1:NrPlots], ...)
   if (NrPlots == 4) list2env(list(height = width, width = height), envir = as.environment(environment()))
   MarkdownHelpers::ww.FnP_parser(fname)
@@ -5146,7 +5146,7 @@ ww.check.quantile.cutoff.and.clip.outliers <- function(expr.vec = plotting.data[
   if (sum(expr.vec.clipped > 0) > min.cells.expressing) {
     expr.vec <- expr.vec.clipped
   } else {
-    iprint("WARNING: quantile.cutoff too stringent, would leave <", min.cells.expressing, "cells. It is NOT applied.")
+    Stringendo::iprint("WARNING: quantile.cutoff too stringent, would leave <", min.cells.expressing, "cells. It is NOT applied.")
   }
   return(expr.vec)
 }
@@ -5206,10 +5206,10 @@ plot3D.umap.gene <- function(
   # browser()
 
   if (obj@version < "5") col.names <- toupper(col.names)
-  message("Obj. version: ", obj@version, " \ndim names: ", kppc(col.names))
+  message("Obj. version: ", obj@version, " \ndim names: ", Stringendo::kppc(col.names))
 
   DefaultAssay(object = obj) <- def.assay
-  iprint(DefaultAssay(object = obj), "assay")
+  Stringendo::iprint(DefaultAssay(object = obj), "assay")
 
   # Get and format 3D plotting data ____________________________________
   plotting.data <- obj@misc$reductions.backup$"umap3d"@cell.embeddings
@@ -5302,7 +5302,7 @@ plot3D.umap <- function(
   )
 
   if (obj@version < "5") col.names <- toupper(col.names)
-  message("Obj. version: ", obj@version, " \ndim names: ", kppc(col.names))
+  message("Obj. version: ", obj@version, " \ndim names: ", Stringendo::kppc(col.names))
 
   # Get and format 3D plotting data ____________________________________
   plotting.data <- obj@misc$reductions.backup$"umap3d"@cell.embeddings # plotting.data <- Seurat::FetchData(object = obj, vars = c(col.names, category))
@@ -5356,9 +5356,9 @@ plot3D.umap <- function(
 #' @importFrom htmlwidgets saveWidget
 SavePlotlyAsHtml <- function(plotly_obj, category. = category, suffix. = NULL) { # Save Plotly 3D scatterplot as an html file.
   OutputDir <- if (exists("OutDir")) OutDir else getwd()
-  name.trunk <- kpp("umap.3D", category., suffix., idate(), "html")
-  fname <- kpps(OutputDir, name.trunk)
-  iprint("Plot saved as:", fname)
+  name.trunk <- Stringendo::kpp("umap.3D", category., suffix., Stringendo::idate(), "html")
+  fname <- Stringendo::kpps(OutputDir, name.trunk)
+  Stringendo::iprint("Plot saved as:", fname)
   htmlwidgets::saveWidget(plotly_obj, file = fname, selfcontained = TRUE, title = category.)
 }
 
@@ -5422,7 +5422,7 @@ SetupReductionsNtoKdimensions <- function(obj = combined.obj, nPCs = p$"n.PC", d
   tictoc::tic()
 
   for (d in dimensions) {
-    iprint("Calculating", d, "dimensional", reduction_output)
+    Stringendo::iprint("Calculating", d, "dimensional", reduction_output)
 
     # Assign the reduction based on the output type
     obj <- switch(reduction_output,
@@ -5464,8 +5464,8 @@ RecallReduction <- function(obj = combined.obj, dim = 2, reduction = "umap") {
   dslot <- paste0(reduction, dim, "d")
   reduction.backup <- obj@misc$reductions.backup[[dslot]]
   msg <- paste(dim, "dimensional", reduction, "from obj@misc$reductions.backup")
-  stopif(is.null(reduction.backup), message = paste0(msg, " is NOT FOUND"))
-  iprint(msg, "is set active. ")
+  Stringendo::stopif(is.null(reduction.backup), message = paste0(msg, " is NOT FOUND"))
+  Stringendo::iprint(msg, "is set active. ")
   stopifnot(dim == ncol(reduction.backup))
   obj@reductions[[reduction]] <- reduction.backup
   return(obj)
@@ -5536,16 +5536,16 @@ Plot3D.ListOfGenes <- function(
   obj = combined.obj # Plot and save list of 3D UMAP or tSNE plots using plotly.
   , annotate.by = "integrated_snn_res.0.7", opacity = 0.5, cex = 1.25, default.assay = c("integrated", "RNA")[2],
   ListOfGenes = c("BCL11B", "FEZF2", "EOMES", "DLX6-AS1", "HOPX", "DDIT4"),
-  SubFolderName = ppp("plot3D", substitute_deparse(ListOfGenes))
+  SubFolderName = Stringendo::ppp("plot3D", Stringendo::substitute_deparse(ListOfGenes))
 ) {
-  try(create_set_SubDir(SubFolderName))
+  try(MarkdownReports::create_set_SubDir(SubFolderName))
   obj. <- obj
   rm("obj")
   stopifnot(annotate.by %in% c(colnames(obj.@meta.data), FALSE))
 
   DefaultAssay(object = obj.) <- default.assay
   MissingGenes <- setdiff(ListOfGenes, rownames(obj.))
-  if (length(MissingGenes)) iprint("These genes are not found, and omitted:", MissingGenes, ". Try to change default assay.")
+  if (length(MissingGenes)) Stringendo::iprint("These genes are not found, and omitted:", MissingGenes, ". Try to change default assay.")
   ListOfGenes <- intersect(ListOfGenes, rownames(obj.))
 
   for (i in 1:length(ListOfGenes)) {
@@ -5554,7 +5554,7 @@ Plot3D.ListOfGenes <- function(
     plot3D.umap.gene(obj = obj., gene = g, annotate.by = annotate.by, alpha = opacity, def.assay = default.assay, dotsize = cex)
   }
   try(oo())
-  try(create_set_Original_OutDir(NewOutDir = ParentDir))
+  try(MarkdownReports::create_set_Original_OutDir(NewOutDir = ParentDir))
 }
 
 
@@ -5584,16 +5584,16 @@ Plot3D.ListOfCategories <- function(
   obj = combined.obj # Plot and save list of 3D UMAP or tSNE plots using plotly.
   , annotate.by = "integrated_snn_res.0.7", cex = 1.25, default.assay = c("integrated", "RNA")[2],
   ListOfCategories = c("v.project", "experiment", "Phase", "integrated_snn_res.0.7"),
-  SubFolderName = ppp("plot3D", substitute_deparse(ListOfCategories))
+  SubFolderName = Stringendo::ppp("plot3D", Stringendo::substitute_deparse(ListOfCategories))
 ) {
-  try(create_set_SubDir(SubFolderName))
+  try(MarkdownReports::create_set_SubDir(SubFolderName))
   obj. <- obj
   rm("obj")
   stopifnot(annotate.by %in% colnames(obj.@meta.data))
   DefaultAssay(object = obj.) <- default.assay
 
   MissingCateg <- setdiff(ListOfCategories, colnames(obj.@meta.data))
-  if (length(MissingCateg)) iprint("These metadata categories are not found, and omitted:", MissingCateg, ". See colnames(obj@meta.data).")
+  if (length(MissingCateg)) Stringendo::iprint("These metadata categories are not found, and omitted:", MissingCateg, ". See colnames(obj@meta.data).")
   ListOfCategories <- intersect(ListOfCategories, colnames(obj.@meta.data))
 
   for (i in 1:length(ListOfCategories)) {
@@ -5602,7 +5602,7 @@ Plot3D.ListOfCategories <- function(
     plot3D.umap(obj = obj., category = categ, annotate.by = annotate.by, dotsize = cex)
   }
   try(oo())
-  try(create_set_Original_OutDir(NewOutDir = ParentDir))
+  try(MarkdownReports::create_set_Original_OutDir(NewOutDir = ParentDir))
 }
 
 
@@ -5704,14 +5704,14 @@ suPlotVariableFeatures <- function(obj = combined.obj, NrVarGenes = 15,
     is.numeric(plotWidth), is.numeric(plotHeight)
   )
 
-  obj.name <- substitute_deparse(obj)
+  obj.name <- Stringendo::substitute_deparse(obj)
 
   plot1 <- Seurat::VariableFeaturePlot(obj, assay = assay, ...) +
     theme(panel.background = element_rect(fill = "white")) +
     labs(
       title = "Variable Genes",
-      subtitle = kppws(obj.name, suffix),
-      caption = paste("Assay:", assay, "|", idate())
+      subtitle = Stringendo::kppws(obj.name, suffix),
+      caption = paste("Assay:", assay, "|", Stringendo::idate())
     )
 
 
@@ -5723,11 +5723,11 @@ suPlotVariableFeatures <- function(obj = combined.obj, NrVarGenes = 15,
   )
 
   print(labeledPlot)
-  filename <- ppp("Var.genes", obj.name, suffix, idate(), "png")
+  filename <- Stringendo::ppp("Var.genes", obj.name, suffix, Stringendo::idate(), "png")
 
   # if (save) ggplot2::ggsave(plot = labeledPlot, filename = filename, width = plotWidth, height = plotHeight)
   if (save) {
-    qqSave(
+    ggExpress::qqSave(
       ggobj = labeledPlot,
       # title = plotname,
       fname = filename, ext = ext,

--- a/R/Seurat.utils.less.used.R
+++ b/R/Seurat.utils.less.used.R
@@ -46,14 +46,14 @@ Convert10Xfolders_v1 <- function(
 
   compress_level <- .map_preset_to_compress_level(preset)
 
-  finOrig <- ReplaceRepeatedSlashes(list.dirs.depth.n(InputDir, depth = depth))
+  finOrig <- Stringendo::ReplaceRepeatedSlashes(list.dirs.depth.n(InputDir, depth = depth))
   fin <- CodeAndRoll2::grepv(x = finOrig, pattern = folderPattern, perl = regex)
 
-  iprint(length(fin), "samples found.")
+  Stringendo::iprint(length(fin), "samples found.")
 
   samples <- basename(list.dirs(InputDir, recursive = FALSE))
   if (sort_alphanumeric) samples <- gtools::mixedsort(samples)
-  iprint("Samples:", samples)
+  Stringendo::iprint("Samples:", samples)
 
   if (!length(fin) > 0) {
     stop(paste("No subfolders found with pattern", folderPattern, "in dirs like: ", finOrig[1:3]))
@@ -88,7 +88,7 @@ Convert10Xfolders_v1 <- function(
       # LSB, Lipid Sample barcode (Multi-seq) --- --- --- --- --- ---
       LSB <- CreateSeuratObject(counts = count_matrix[[2]], project = fnameIN)
 
-      LSBnameOUT <- ppp(paste0(InputDir, "/LSB.", fnameIN), "qs")
+      LSBnameOUT <- Stringendo::ppp(paste0(InputDir, "/LSB.", fnameIN), "qs")
       qs2::qs_save(object = LSB, file = LSBnameOUT, compress_level = compress_level)
     } else {
       print("More than 2 elements in the list of matrices")
@@ -114,7 +114,7 @@ Convert10Xfolders_v1 <- function(
     if (writeCBCtable) {
       CBCs <- t(t(colnames(seu)))
       colnames(CBCs) <- "CBC"
-      ReadWriter::write.simple.tsv(input_df = CBCs, manual_file_name = sppp(fnameIN, "CBC"), manual_directory = InputDir)
+      ReadWriter::write.simple.tsv(input_df = CBCs, manual_file_name = Stringendo::sppp(fnameIN, "CBC"), manual_directory = InputDir)
     }
   } # for
 }
@@ -176,7 +176,7 @@ plot.UMAP.tSNE.sidebyside <- function(obj = combined.obj, grouping = "res.0.6", 
   p2 <- p2 + Seurat::NoLegend()
 
   plots <- cowplot::plot_grid(p1, p2, labels = c("A", "B"), ncol = 2)
-  plotname <- kpp("UMAP.tSNE", grouping, name.suffix, filetype)
+  plotname <- Stringendo::kpp("UMAP.tSNE", grouping, name.suffix, filetype)
 
   cowplot::save_plot(
     filename = plotname, plot = plots,
@@ -260,7 +260,7 @@ multi_clUMAP.A4 <- function(
   tictoc::tic()
   ParentDir <- OutDir
   if (is.null(foldername)) foldername <- "clusters"
-  if (subdir) create_set_SubDir(paste0(foldername, "-", plot.reduction), "/")
+  if (subdir) MarkdownReports::create_set_SubDir(paste0(foldername, "-", plot.reduction), "/")
 
   DefaultAssay(obj) <- intersectionAssay
 
@@ -272,8 +272,8 @@ multi_clUMAP.A4 <- function(
   ls.idents <- CodeAndRoll2::split_vec_to_list_by_N(1:length(idents), by = nr.Row * nr.Col)
   for (i in 1:length(ls.idents)) {
     idents_on_this_page <- idents[ls.idents[[i]]]
-    iprint("page:", i, "| idents", kppc(idents_on_this_page))
-    (plotname <- kpp(c(prefix, plot.reduction, i, "idents", ls.idents[[i]], suffix, format)))
+    Stringendo::iprint("page:", i, "| idents", Stringendo::kppc(idents_on_this_page))
+    (plotname <- Stringendo::kpp(c(prefix, plot.reduction, i, "idents", ls.idents[[i]], suffix, format)))
 
     plot.list <- list()
     for (i in seq(idents_on_this_page)) {
@@ -287,7 +287,7 @@ multi_clUMAP.A4 <- function(
       }
 
       ident_X <- idents_on_this_page[i]
-      imessage("plotting:", ident_X)
+      Stringendo::imessage("plotting:", ident_X)
       plot.list[[i]] <- clUMAP(
         ident = ident_X, obj = obj, plotname = label_X,
         label = label_X, legend = legend_X, save.plot = FALSE, h = h, w = w, ...
@@ -339,7 +339,7 @@ umapNamedClusters <- function(obj = combined.obj,
                               metaD.colname = metaD.colname.labeled,
                               ext = "png", ...) {
   warning("This function is deprecated. No support.")
-  fname <- ppp("Named.clusters", metaD.colname, ext)
+  fname <- Stringendo::ppp("Named.clusters", metaD.colname, ext)
   p.named <-
     Seurat::DimPlot(obj, reduction = "umap", group.by = metaD.colname, label = TRUE, ...) +
     NoLegend() +
@@ -383,7 +383,7 @@ AutoNumber.by.PrinCurve <- function(
   reduction = "umap", res = "integrated_snn_res.0.5"
 ) {
   # require(princurve)
-  dim_name <- ppu(toupper(reduction), dim)
+  dim_name <- Stringendo::ppu(toupper(reduction), dim)
   coord.umap <- FetchData(object = obj, vars = dim_name)
   fit <- princurve::principal_curve(x = as.matrix(coord.umap))
   if (plotit) {
@@ -398,12 +398,12 @@ AutoNumber.by.PrinCurve <- function(
   }
 
   ls.perCl <- split(swap * fit$lambda, f = obj[[res]])
-  MedianClusterCoordinate <- unlapply(ls.perCl, median)
+  MedianClusterCoordinate <- CodeAndRoll2::unlapply(ls.perCl, median)
   OldLabel <- names(sort(MedianClusterCoordinate))
   NewLabel <- as.character(0:(length(MedianClusterCoordinate) - 1))
-  NewMeta <- translate(vec = obj[[res]], old = OldLabel, new = NewLabel)
-  NewMetaCol <- kpp(res, "prin.curve")
-  iprint("NewMetaCol:", NewMetaCol)
+  NewMeta <- CodeAndRoll2::translate(vec = obj[[res]], old = OldLabel, new = NewLabel)
+  NewMetaCol <- Stringendo::kpp(res, "prin.curve")
+  Stringendo::iprint("NewMetaCol:", NewMetaCol)
   obj[[NewMetaCol]] <- NewMeta
   return(obj)
 }
@@ -463,7 +463,7 @@ load10Xv3 <- function(dataDir, cellIDs = NULL, channelName = NULL, readArgs = li
   dirz <- list.dirs(dataDir, full.names = FALSE, recursive = FALSE)
   path.raw <- file.path(dataDir, grep(x = dirz, pattern = "^raw_*", value = TRUE))
   path.filt <- file.path(dataDir, grep(x = dirz, pattern = "^filt_*", value = TRUE))
-  CR.matrices <- list.fromNames(c("raw", "filt"))
+  CR.matrices <- CodeAndRoll2::list.fromNames(c("raw", "filt"))
 
 
   (isV3 <- any(grepl(x = dirz, pattern = "^raw_feature_bc*")))
@@ -595,7 +595,7 @@ Convert10Xfolders.old <- function(
     pathIN <- fin[i]
     print(pathIN)
     fnameIN <- basename(fin[i])
-    fnameOUT <- ppp(paste0(InputDir, "/", fnameIN), "min.cells", min.cells, "min.features", min.features, "Rds")
+    fnameOUT <- Stringendo::ppp(paste0(InputDir, "/", fnameIN), "min.cells", min.cells, "min.features", min.features, "Rds")
     count_matrix <- Read10X(pathIN)
 
     if (!is.list(count_matrix) | length(count_matrix) == 1) {
@@ -611,7 +611,7 @@ Convert10Xfolders.old <- function(
 
       # LSB, Lipid Sample barcode (Multi-seq) --- --- --- --- --- ---
       LSB <- CreateSeuratObject(counts = count_matrix[[2]], project = fnameIN)
-      LSBnameOUT <- ppp(paste0(InputDir, "/LSB.", fnameIN), "Rds")
+      LSBnameOUT <- Stringendo::ppp(paste0(InputDir, "/LSB.", fnameIN), "Rds")
       saveRDS(LSB, file = LSBnameOUT)
     } else {
       print("More than 2 elements in the list of matrices")
@@ -690,7 +690,7 @@ seu.add.meta.from.vector <- function(...) .Deprecated("addMetaDataSafe()")
 
 # will it be used?
 cellID_to_cellType_v1 <- function(cellIDs, ident, obj = aaa) {
-  celltypes <- as.named.vector.df(obj@meta.data[, ident], verbose = FALSE)
+  celltypes <- CodeAndRoll2::as.named.vector.df(obj@meta.data[, ident], verbose = FALSE)
   celltypes[cellIDs]
 }
 
@@ -950,7 +950,7 @@ plotClustSizeDistr <- function(
   psubtitle <- paste(
     "Nr.clusters:", length(clust.size.distr),
     "| median size:", median(clust.size.distr),
-    "| CV:", percentage_formatter(cv(clust.size.distr))
+    "| CV:", Stringendo::percentage_formatter(CodeAndRoll2::cv(clust.size.distr))
   )
   xlb <- "Cluster size (cells)"
   ylb <- "Nr of Clusters"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ Functionalities rely on basic function libraries listed below.
 # Installation
 
 ### !!! Installation NEWS 
-#### `qs` dependency
-- Until I update the code to [`qs2`](https://github.com/qsbase/qs2), you have to install `qs` [from GitHub](https://github.com/qsbase/qs):
-`remotes::install_cran("qs", type = "source", configure.args = "--with-simd=AVX2")`
-- Unfortunately as of R4.6.0 `qs` reportedly fails to install on R4.6.x on Windows.
-- Solution: **Use R4.5.x until I can upgrade the package**
+#### `qs2` dependency
+- Serialization helpers now use [`qs2`](https://github.com/qsbase/qs2), which currently declares `R (>= 3.6.0)`, so R 4.5.x is supported.
+- If `qs2` installation fails, update its compiled dependencies first (`RcppParallel` and `stringfish`), then reinstall `qs2`.
+- The old `qs` package is no longer needed by Seurat.utils.
 
 Seurat.utils relies on:
 


### PR DESCRIPTION
## Summary
1. Replaces `qs` with `qs2` in `DESCRIPTION` Imports (code only calls `qs2::`).
2. Makes all 542 bare calls to sibling-package functions explicit (e.g. `CodeAndRoll2::nr.unique()`), across all 4 `R/` files. No behavior change.

## Why
(1): a leftover from the recent merge-conflict cleanup (#135) -- the declared package didn't match what the code actually calls.
(2): these calls only worked because their packages happen to be attached. Writing them as `Package::function()` makes the source of every function obvious at a glance.

## Scope
Only calls into Seurat.utils's own dependency packages (Stringendo, CodeAndRoll2, MarkdownReports, ggExpress, MarkdownHelpers, ReadWriter) were touched. External libraries (Seurat, ggplot2, etc.) and base R are untouched -- that's a separate pass. Bare function references passed *by name* (not called), e.g. `apply(x, 1, kppu)`, are also untouched -- only actual call sites.
