### PR TITLE
Annotate code: explain non-obvious operations

### DIFF
--- a/R/Seurat.Utils.Metadata.R
+++ b/R/Seurat.Utils.Metadata.R
@@ -64,6 +64,9 @@ addTranslatedMetadata <- function(obj = combined.obj,
   )
   print(table(new, useNA = "ifany"))
 
+  # NOTE: BUG -- 'x' is only assigned when plot = TRUE, but print(x) below runs
+  # unconditionally; with the default plot = FALSE this errors with
+  # "object 'x' not found" on every call.
   if (plot) x <- clUMAP(ident = new_col_name, obj = obj, caption = "New metadata column", ...)
   print(x)
   return(obj)

--- a/R/Seurat.Utils.R
+++ b/R/Seurat.Utils.R
@@ -477,6 +477,10 @@ runDGEA <- function(obj,
         min.diff.pct = param.list$"min.diff.pct",
         min.cells.group = param.list$"min.cells.group",
         max.cells.per.ident = param.list$"max.cells.per.ident",
+        # NOTE: BUG -- 'only.pos' is passed twice. R errors immediately on a
+        # duplicated named argument ("formal argument matched by multiple
+        # actual arguments"), so this call -- and calculate.DGEA = TRUE,
+        # the default -- always crashes.
         only.pos = param.list$"only.pos",
         only.pos = param.list$"only.pos"
       )
@@ -2525,7 +2529,8 @@ RelabelSmallCategories <- function(
 
   message("backup_col_name: ", backup_col_name)
 
-  # Extract the specified metadata column
+  # Chained assignment: back up the original column under backup_col_name,
+  # and also capture its value in `categories` for use below -- in one step.
   categories <- obj@meta.data[[backup_col_name]] <- obj@meta.data[[col_in]]
 
   # Count occurrences of each category
@@ -3172,7 +3177,7 @@ GetTopMarkersDF <- function(
     "^MIR[1-9]", "^SNHG[1-9]"
   )
 ) {
-  "Works on active Idents() -> thus we call cluster"
+  # Works on active Idents() -> thus we call it "cluster" below.
   combined_pattern <- paste(exclude, collapse = "|")
 
   TopMarkers <- dfDE |>
@@ -3398,13 +3403,6 @@ AutoLabel.KnownMarkers <- function(
 
   print("Best matches:")
   print(unique.matches)
-
-  "Error Here"
-  "Error Here"
-  "Error Here"
-  "Error Here"
-  "Error Here"
-  "Error Here"
 
   top.markers.df <- GetTopMarkersDF(dfDE = df_markers, order.by = lfcCOL, n = 1)
   top.markers <- top.markers.df |> col2named.vec.tbl()
@@ -4503,8 +4501,8 @@ RemoveGenesSeurat <- function(obj = ls.Seurat[[i]], symbols2remove = c("TOP2A"))
 HGNC.EnforceUnique <- function(updatedSymbols) {
   NGL <- updatedSymbols[, 3]
   if (any.duplicated(NGL)) {
+    # Unique names are enforced by suffixing .1, .2, etc.
     updatedSymbols[, 3] <- make.unique(NGL)
-    "Unique names are enforced by suffixing .1, .2, etc."
   }
   return(updatedSymbols)
 }
@@ -4611,8 +4609,8 @@ PlotUpdateStats <- function(mat = UpdateStatMat, column.names = c("Updated (%)",
 # source('~/GitHub/Packages/Seurat.utils/Functions/Read.Write.Save.Load.functions.R')
 # try (source("https://raw.githubusercontent.com/vertesy/Seurat.utils/master/Functions/Read.Write.Save.Load.functions.R"))
 
-"Multicore read / write (I/O) functions are https://github.com/vertesy/Seurat.multicore"
-"Single core read / write (I/O) functions are in https://github.com/vertesy/Seurat.utils/"
+# Multicore read / write (I/O) functions are https://github.com/vertesy/Seurat.multicore
+# Single core read / write (I/O) functions are in https://github.com/vertesy/Seurat.utils/
 
 
 # _________________________________________________________________________________________________
@@ -4659,6 +4657,11 @@ Convert10Xfolders <- function(
   save_empty_droplets = TRUE,
   ...
 ) {
+  # NOTE: BUG -- 'save' (checked below, and used later via `if (save) qs2::qs_save(...)`)
+  # is not a formal argument of this function. It resolves to base::save() (a function,
+  # so is.logical(save) is FALSE), which makes this stopifnot() always fail -- unless the
+  # caller happens to have a logical variable named `save` masking base::save() in scope.
+  # A `save = TRUE` argument passed by a caller is silently absorbed by `...` and ignored.
   stopifnot(
     is.character(InputDir), dir.exists(InputDir),
     is.logical(regex), is.character(folderPattern), is.character(suffix), is.numeric(depth),
@@ -5476,6 +5479,9 @@ qsave.image <- function(
   save.image(file = fname, compress = FALSE)
   iprint("Saved, being compressed", fname)
   system(paste("gzip", options, fname), wait = FALSE) # execute in the background
+  # NOTE: BUG -- `cat()` cannot handle a closure; this passes the function itself
+  # (not its result), so this always errors ("argument 1 (type 'closure') cannot be
+  # handled by 'cat'") instead of printing the elapsed time. Likely meant `tictoc::toc()`.
   cat(tictoc::toc)
 }
 
@@ -6259,6 +6265,9 @@ compareVarFeaturesAndRanks <- function(
   }
 
   # Find the ScaleData command using the helper function
+  # NOTE: BUG -- .FindCommandInObject() calls stop() (not return(NULL)) when there is no
+  # match, so this intended graceful fallback is unreachable: the function always errors
+  # out here instead of returning NULL when no ScaleData command is found in @commands.
   func_slot <- .FindCommandInObject(obj, pattern = paste0("^ScaleData.", assay))
 
   if (is.null(func_slot)) {

--- a/R/Seurat.Utils.Visualization.R
+++ b/R/Seurat.Utils.Visualization.R
@@ -1253,7 +1253,6 @@ scBarplot.CellsPerCluster <- function(
     is.numeric(ylab_adj), is.numeric(min.cells), ident %in% colnames(obj@meta.data)
   )
 
-  1
   cell.per.cl <- obj[[ident]][, 1]
   cell.per.cluster <- (table(cell.per.cl, useNA = "ifany"))
   if (sort) cell.per.cluster <- sort(cell.per.cluster)
@@ -4347,6 +4346,11 @@ scGeneConceptNetworkEnrichr <- function(
 }
 
 
+# NOTE: BUG -- the next four functions (scBarplotEnrichr, scDotplotEnrichr, scEmapplotEnrichr,
+# scGeneConceptNetworkEnrichr) are exact byte-for-byte duplicates of the definitions just above.
+# Harmless at runtime (the later definition simply overwrites the earlier one when the package
+# loads), but this is ~450 lines of dead, duplicated source -- likely an accidental copy-paste
+# or merge artifact. Safe to delete this whole duplicated block.
 # ________________________________________________________________________
 #' @title Barplot GO Enrichment Results by enrichplot
 #'
@@ -5727,6 +5731,9 @@ suPlotVariableFeatures <- function(obj = combined.obj, NrVarGenes = 15,
 
   # if (save) ggplot2::ggsave(plot = labeledPlot, filename = filename, width = plotWidth, height = plotHeight)
   if (save) {
+    # NOTE: BUG -- `ext` is not a formal argument of this function and is never assigned
+    # locally, so with the default save = TRUE this errors ("object 'ext' not found")
+    # unless a global variable `ext` happens to exist in the caller's environment.
     qqSave(
       ggobj = labeledPlot,
       # title = plotname,

--- a/R/Seurat.utils.less.used.R
+++ b/R/Seurat.utils.less.used.R
@@ -297,6 +297,10 @@ multi_clUMAP.A4 <- function(
     # Customize plot appearance
     for (i in 1:length(plot.list)) {
       plot.list[[i]] <- plot.list[[i]] + NoAxes()
+      # NOTE: BUG -- missing `+`: this assigns plot.list[[i]] to itself (no-op), then
+      # evaluates ggplot2::coord_fixed(...) as an unused, separate statement. aspect.ratio
+      # is silently never applied. Should be one expression:
+      # plot.list[[i]] <- plot.list[[i]] + ggplot2::coord_fixed(ratio = aspect.ratio)
       if (aspect.ratio) plot.list[[i]] <- plot.list[[i]]
       ggplot2::coord_fixed(ratio = aspect.ratio)
     }
@@ -719,8 +723,6 @@ Create.MiscSlot <- function(obj, NewSlotName = "UVI.tables", SubSlotName = NULL)
 # Archived ----
 # _________________________________________________________________________________________________
 
-".Deprecated"
-
 #' @title Regress Out and Recalculate Seurat
 #'
 #' @description The function performs a series of calculations and manipulations on a Seurat object,
@@ -969,7 +971,7 @@ plotClustSizeDistr <- function(
       )
     }
   } else {
-    "return vector"
+    # plot = FALSE: return the cluster size table instead of plotting
     clust.size.distr
   }
 }


### PR DESCRIPTION
## Summary
Added comments explaining non-obvious logic across all 4 `R/` source files (~15,450 lines total), and normalized a few stray string-literal "comments" into real `#` comments. Most of the codebase was already well documented via roxygen, so most new comments are concentrated on genuinely tricky spots.

## Bugs found while reading (not fixed, just flagged with `# NOTE:` comments)
This is by far the largest file in the ecosystem, and it shows: **8 real bugs found**, most of which mean the affected function crashes (or silently no-ops) on every default call.

- **`addTranslatedMetadata()`** (Metadata.R): calls `print(x)` unconditionally, but `x` is only assigned when `plot = TRUE`. Crashes on every default call.
- **`runDGEA()`**: passes `only.pos = param.list$"only.pos"` twice to `Seurat::FindAllMarkers()` — a duplicate named argument is a fatal R error. Crashes whenever `calculate.DGEA = TRUE` (the default).
- **`Convert10Xfolders()`**: `stopifnot()` checks `is.logical(save)`, but `save` is not a formal argument of the function — it resolves to `base::save` (a function), so the check always fails.
- **`qsave.image()`**: ends with `cat(tictoc::toc)` instead of `tictoc::toc()` — `cat()` can't handle a closure, so this always errors instead of printing elapsed time.
- **`.getRegressionVariablesForScaleData()`**: its "no ScaleData command found" fallback is unreachable, because the helper it calls (`.FindCommandInObject()`) throws an error instead of returning `NULL` in that case.
- **`suPlotVariableFeatures()`**: references an `ext` variable that's never defined (not a parameter, not assigned) — errors with the default `save = TRUE`.
- **Duplicate code (Visualization.R)**: `scBarplotEnrichr()`, `scDotplotEnrichr()`, `scEmapplotEnrichr()`, and `scGeneConceptNetworkEnrichr()` are each defined **twice**, back-to-back, byte-for-byte identical (~450 lines of dead duplication). Harmless at runtime (last definition wins), but worth deleting.
- **`multi_clUMAP.A4()`** (less.used.R, deprecated): missing a `+` before `ggplot2::coord_fixed(...)` means the aspect-ratio adjustment is silently never applied.

Flagging all of these for your call on whether/how to fix; didn't want to bundle behavior changes into a comments-only PR.
